### PR TITLE
Set up coveralls and code climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
+ after_success:
+ - CODECLIMATE_REPO_TOKEN=CODECLIMATE_TEST_REPORTER_TOKEN codeclimate-test-reporter < ./coverage/coverage.lcov
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,13 @@ notifications:
   slack:
     secure: "JixoZ73+2QvMT0Q1SzlaeXXXNWyjZVw6n6rYHPdd3DWKnvj+4utjqshBn8/bI1l8lEF5E08CFBqe/Diil49/VYLwt6YjfEv23axMjwFXAZSr8A+UgGjkyuZDOdmMBDZvQWEsXjWlGJB/FA650QHzt0ma5IYL0BZOa4kDpKUDec98EDtxritmL17D/DeuvMDIBYwYhDvvj2yMXD7ZlC/GRMY3UZzZXtqEAHy3gYFWsEE99m2hnyebs1mmYFNapUJ4eH88SHpACLuDpS2W4Mb+hgXqbknjEhndRHPEg/+YRpDAajBZDFCq9LPne9uL1eM9QbPfbV5Dg/Xf7NoiVQlJX63W6SlIOjTi1cCJ+EE9fqMV4P3r1IV+d0GD+C4TSlm80gseHZ1icQAhSFu9AyLpZIkcJNAVYVHUZd5rAvDHvw4gSJqQG+zMU9lIepuZYHzjufWE98gZvb4Zo2yr3kmbWbaXlxea/Cu9LBnFP4td6M+X/ff/pqzH09huher7N9ljPMKTeKeg/EfCXmojkIOXYET4hoXBedisJW5GBZ+447aFGqzucr075e4H0kcgVoHxQ7Ekwr1OTdw4Nlib1AJsb39jdMwOzhGCGhRBhHQ+292enMoAQwejpHULW1Q5OUoN3dYZKf80pSME2zuYAWOJTtA8C3r9brfgwVZMUY8UrFs="
 before_install:
- - export CHROME_BIN=/usr/bin/google-chrome
- - export DISPLAY=:99.0
- - sh -e /etc/init.d/xvfb start
- - sudo apt-get update
- - sudo apt-get install -y libappindicator1 fonts-liberation
- - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
- - sudo dpkg -i google-chrome*.deb
- after_success:
- - CODECLIMATE_REPO_TOKEN=CODECLIMATE_TEST_REPORTER_TOKEN codeclimate-test-reporter < ./coverage/coverage.lcov
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,21 @@ node_js:
   - "5"
 notifications:
   slack:
+    # Tell Travis CI to send a notification about the build status to our slack channel (encrypted to prevent other people to send notification with the token)
     secure: "JixoZ73+2QvMT0Q1SzlaeXXXNWyjZVw6n6rYHPdd3DWKnvj+4utjqshBn8/bI1l8lEF5E08CFBqe/Diil49/VYLwt6YjfEv23axMjwFXAZSr8A+UgGjkyuZDOdmMBDZvQWEsXjWlGJB/FA650QHzt0ma5IYL0BZOa4kDpKUDec98EDtxritmL17D/DeuvMDIBYwYhDvvj2yMXD7ZlC/GRMY3UZzZXtqEAHy3gYFWsEE99m2hnyebs1mmYFNapUJ4eH88SHpACLuDpS2W4Mb+hgXqbknjEhndRHPEg/+YRpDAajBZDFCq9LPne9uL1eM9QbPfbV5Dg/Xf7NoiVQlJX63W6SlIOjTi1cCJ+EE9fqMV4P3r1IV+d0GD+C4TSlm80gseHZ1icQAhSFu9AyLpZIkcJNAVYVHUZd5rAvDHvw4gSJqQG+zMU9lIepuZYHzjufWE98gZvb4Zo2yr3kmbWbaXlxea/Cu9LBnFP4td6M+X/ff/pqzH09huher7N9ljPMKTeKeg/EfCXmojkIOXYET4hoXBedisJW5GBZ+447aFGqzucr075e4H0kcgVoHxQ7Ekwr1OTdw4Nlib1AJsb39jdMwOzhGCGhRBhHQ+292enMoAQwejpHULW1Q5OUoN3dYZKf80pSME2zuYAWOJTtA8C3r9brfgwVZMUY8UrFs="
 before_install:
+  # Tell Travis CI that we are testing on Chrome
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
+  # Install Chrome
   - sh -e /etc/init.d/xvfb start
   - sudo apt-get update
   - sudo apt-get install -y libappindicator1 fonts-liberation
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
 after_success:
+  # Send test coverage data to code climate and coveralls
+  # CODECLIMATE_TEST_REPORTER_TOKEN is an environment variable set in Travis CI to keep token secret
   - CODECLIMATE_REPO_TOKEN=CODECLIMATE_TEST_REPORTER_TOKEN codeclimate-test-reporter < ./coverage/coverage.lcov
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/coverage.lcov
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ before_install:
   - sudo apt-get install -y libappindicator1 fonts-liberation
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
+after_success:
+  - CODECLIMATE_REPO_TOKEN=CODECLIMATE_TEST_REPORTER_TOKEN codeclimate-test-reporter < ./coverage/coverage.lcov
+  - ./node_modules/coveralls/bin/coveralls.js < ./coverage/coverage.lcov
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "angular-cli": "^1.0.0-beta.26",
     "codeclimate-test-reporter": "^0.4.0",
     "codecov": "^1.0.1",
+    "coveralls": "^2.11.15",
     "jasmine-core": "^2.5.2",
     "jasmine-spec-reporter": "^3.2.0",
     "karma": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.3",
     "angular-cli": "^1.0.0-beta.26",
+    "codeclimate-test-reporter": "^0.4.0",
     "codecov": "^1.0.1",
     "jasmine-core": "^2.5.2",
     "jasmine-spec-reporter": "^3.2.0",


### PR DESCRIPTION
Resolve #8 

Simply added a few scripts to execute after a successful build on travis to transmit coverage info to coveralls and code climate.