### PR TITLE
Add hal support

### DIFF
--- a/ionic.config.json
+++ b/ionic.config.json
@@ -2,11 +2,5 @@
   "name": "stockpile",
   "app_id": "90c804f8",
   "v2": true,
-  "typescript": true,
-  "proxies": [
-    {
-      "path": "/api",
-      "proxyUrl": "http://localhost:5000"
-    }
-  ]
+  "typescript": true
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,7 @@ module.exports = function (config) {
       require('angular-cli/plugins/karma')
     ],
     files: [
+      './src/extends-script.js', // Temporary fix for ng-hal
       { pattern: './src/test.ts', watched: false }
     ],
     preprocessors: {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ionic-angular": "2.0.0",
     "ionic-native": "2.4.1",
     "ionicons": "3.0.0",
-    "ng-hal": "^0.2.0",
+    "ng-hal": "^0.3.0",
     "rxjs": "5.0.0-beta.12",
     "sw-toolbox": "3.4.0",
     "zone.js": "0.6.26"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ionic-angular": "2.0.0",
     "ionic-native": "2.4.1",
     "ionicons": "3.0.0",
+    "ng-hal": "^0.2.0",
     "rxjs": "5.0.0-beta.12",
     "sw-toolbox": "3.4.0",
     "zone.js": "0.6.26"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { Platform } from 'ionic-angular';
 import { StatusBar, Splashscreen } from 'ionic-native';
 
 import { LoginPage } from '../pages/login/login';
+import { StockpileData } from '../providers/stockpile-data';
 
 
 @Component({
@@ -11,10 +12,11 @@ import { LoginPage } from '../pages/login/login';
 export class MyApp {
   rootPage = LoginPage;
 
-  constructor(platform: Platform) {
+  constructor(platform: Platform, public stockpileData: StockpileData) {
     platform.ready().then(() => {
       // Okay, so the platform is ready and our plugins are available.
       // Here you can do any higher level native things you might need.
+      this.stockpileData.initHal();
       StatusBar.styleDefault();
       Splashscreen.hide();
     });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,12 +2,14 @@ import { NgModule, ErrorHandler } from '@angular/core';
 import { IonicApp, IonicModule, IonicErrorHandler } from 'ionic-angular';
 import { CloudSettings, CloudModule } from '@ionic/cloud-angular';
 import { MyApp } from './app.component';
+import { HalModule } from 'ng-hal';
 import { AddItemPage } from '../pages/add-item/add-item';
 import { HomePage } from '../pages/home/home';
 import { InventoryPage } from '../pages/inventory/inventory';
 import { LoginPage } from '../pages/login/login';
 import { TabsPage } from '../pages/tabs/tabs';
 import { UserData } from '../providers/user-data';
+import { StockpileData } from '../providers/stockpile-data';
 import { InventoryData } from '../providers/inventory-data';
 
 const cloudSettings: CloudSettings = {
@@ -27,7 +29,8 @@ const cloudSettings: CloudSettings = {
   ],
   imports: [
     IonicModule.forRoot(MyApp),
-    CloudModule.forRoot(cloudSettings)
+    CloudModule.forRoot(cloudSettings),
+    HalModule
   ],
   bootstrap: [IonicApp],
   entryComponents: [
@@ -38,6 +41,6 @@ const cloudSettings: CloudSettings = {
     LoginPage,
     TabsPage
   ],
-  providers: [{provide: ErrorHandler, useClass: IonicErrorHandler}, InventoryData, UserData]
+  providers: [{provide: ErrorHandler, useClass: IonicErrorHandler}, InventoryData, UserData, StockpileData]
 })
 export class AppModule {}

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,4 +1,4 @@
-import { PlatformMock } from '../mocks';
+import { PlatformMock, StockpileDataMock } from '../mocks';
 import { MyApp } from './app.component';
 import { LoginPage } from '../pages/login/login';
 
@@ -7,7 +7,7 @@ let instance: any = null;
 describe('Root Component', () => {
 
   beforeEach(() => {
-    instance = new MyApp((<any> new PlatformMock));
+    instance = new MyApp((<any> new PlatformMock), (<any> new StockpileDataMock));
   });
 
   it('is created', () => {

--- a/src/extends-script.js
+++ b/src/extends-script.js
@@ -1,0 +1,25 @@
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
   <link href="build/main.css" rel="stylesheet">
 
   <!-- Temporary fix to make ng-hal work. Get `RerefenceError: __extends is not defined` wihtout it.
-  I opened a pull request with the real fix on the ng-hal repo (https://github.com/dherges/ng-hal/pull/3) -->
+  I opened an issue on the ng-hal repo (https://github.com/dherges/ng-hal/issues/2) -->
   <script>
     var __extends = (this && this.__extends) || function (d, b) {
         for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,35 @@
 
   <link href="build/main.css" rel="stylesheet">
 
+  <!-- Temporary fix to make ng-hal work. Get `RerefenceError: __extends is not defined` wihtout it.
+  I opened a pull request with the real fix on the ng-hal repo (https://github.com/dherges/ng-hal/pull/3) -->
+  <script>
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var __metadata = (this && this.__metadata) || function (k, v) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+    };
+    var __param = (this && this.__param) || function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+    var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments)).next());
+        });
+    };
+  </script>
 </head>
 <body>
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -97,16 +97,20 @@ export class NavParamsMock {
   }
 }
 
-export class UserDataMock {
-  public login(): any {
+export class InventoryDataMock {
+  public addItem(): any {
     return new Promise((resolve, reject) => {
       resolve();
     });
   }
 }
 
-export class InventoryDataMock {
-  public addItem(): any {
+export class StockpileDataMock {
+  public initHal(): any { }
+}
+
+export class UserDataMock {
+  public login(): any {
     return new Promise((resolve, reject) => {
       resolve();
     });

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -3,6 +3,9 @@
 
 // IONIC:
 
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/Rx';
+
 export class ConfigMock {
 
   public get(): any {
@@ -94,6 +97,18 @@ export class MenuMock {
 export class NavParamsMock {
   public get(key): any {
     return String(key);
+  }
+}
+
+export class NavigatorMock {
+  hal = {};
+
+  public get(): any {
+    let promise = new Promise((resolve, reject) => {
+      resolve(this.hal);
+    });
+
+    return Observable.fromPromise(promise);
   }
 }
 

--- a/src/providers/stockpile-data.spec.ts
+++ b/src/providers/stockpile-data.spec.ts
@@ -1,14 +1,22 @@
+import { fakeAsync, tick } from '@angular/core/testing';
 import { StockpileData } from './stockpile-data';
+import { NavigatorMock } from '../mocks';
 
 let stockpileData: StockpileData = null;
 
 describe('StockpileData Provider', () => {
 
   beforeEach(() => {
-    stockpileData = new StockpileData();
+    stockpileData = new StockpileData(<any> new NavigatorMock);
   });
 
   it('is created', () => {
     expect(stockpileData).not.toBeNull();
   });
+
+  it('gets a hal doc on init()', fakeAsync(() => {
+    stockpileData.initHal();
+    tick();
+    expect(stockpileData.hal).toBeTruthy();
+  }));
 });

--- a/src/providers/stockpile-data.spec.ts
+++ b/src/providers/stockpile-data.spec.ts
@@ -1,0 +1,14 @@
+import { StockpileData } from './stockpile-data';
+
+let stockpileData: StockpileData = null;
+
+describe('StockpileData Provider', () => {
+
+  beforeEach(() => {
+    stockpileData = new StockpileData();
+  });
+
+  it('is created', () => {
+    expect(stockpileData).not.toBeNull();
+  });
+});

--- a/src/providers/stockpile-data.ts
+++ b/src/providers/stockpile-data.ts
@@ -5,11 +5,11 @@ import { Navigator, HalDocument } from 'ng-hal';
 export class StockpileData {
   hal: HalDocument;
 
-  constructor(private navigator: Navigator) { }
+  constructor(public navigator: Navigator) { }
 
   initHal() {
     this.navigator
       .get('https://stockpile.adamvig.com/api')
-      .subscribe((doc: HalDocument) => console.log(doc));
+      .subscribe((doc: HalDocument) => this.hal = doc);
   }
 }

--- a/src/providers/stockpile-data.ts
+++ b/src/providers/stockpile-data.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Navigator, HalDocument } from 'ng-hal';
+
+@Injectable()
+export class StockpileData {
+  hal: HalDocument;
+
+  constructor(private navigator: Navigator) { }
+
+  initHal() {
+    this.navigator
+      .get('https://stockpile.adamvig.com/api')
+      .subscribe((doc: HalDocument) => console.log(doc));
+  }
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -58,11 +58,12 @@ export class TestUtils {
         ...components,
       ],
       providers: [
-        App, Form, Keyboard, DomController, MenuController, GestureController, NgForm, InventoryData, UserData,
-        {provide: Platform, useClass: PlatformMock},
-        {provide: Config, useClass: ConfigMock},
-        {provide: NavController, useClass: NavMock},
-        {provide: NavParams, useClass: NavParamsMock}
+        App, Form, Keyboard, DomController, MenuController, GestureController,
+        NgForm, InventoryData, UserData,
+        { provide: Platform, useClass: PlatformMock },
+        { provide: Config, useClass: ConfigMock },
+        { provide: NavController, useClass: NavMock },
+        { provide: NavParams, useClass: NavParamsMock }
       ],
       imports: [
         FormsModule,


### PR DESCRIPTION
Added support for HAL. `app.component.ts` makes a call to the api root to get the links.

I had to add an ugly script in `src/index.html` and `karma.conf.js` because the [ng-hal](https://github.com/dherges/ng-hal) module I use to construct the hal object does not work properly. Adding this script is the temporary fix. I opened an issue on the ng-hal repo, but the author does not have enough time to investigate the issue, so we will have to stick with this for now.

I also opened [an issue](https://github.com/emmanuelroussel/stockpile-app/issues/48) to add support for env variables to move the api link there.

Close #49 