### PR TITLE
Add authentication for organizations

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <widget id="app.stockpile.stockpileapp" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>Stockpile</name>
   <description>An app that manages stuff for organizations</description>
-  <author email="emman.roussel@gmail.com" href="#">Stockpile Team</author>
+  <author email="emman.roussel@gmail.com" href="">Stockpile Team</author>
   <content src="index.html"/>
   <access origin="*"/>
   <allow-navigation href="http://ionic.local/*"/>

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="app.stockpile.stockpileapp" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="app.stockpile.stockpileapp" version="0.1.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>Stockpile</name>
   <description>An app that manages stuff for organizations</description>
   <author email="emman.roussel@gmail.com" href="">Stockpile Team</author>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-server": "2.2.1",
     "@ionic/cloud-angular": "^0.9.1",
     "@ionic/storage": "1.1.7",
+    "angular2-jwt": "0.1.25",
     "ionic-angular": "2.0.1",
     "ionic-native": "2.4.1",
     "ionicons": "3.0.0",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { Platform } from 'ionic-angular';
+import { Component, ViewChild } from '@angular/core';
+import { Nav, Platform, MenuController } from 'ionic-angular';
 import { StatusBar, Splashscreen } from 'ionic-native';
 
 import { LoginPage } from '../pages/login/login';
@@ -7,17 +7,18 @@ import { TabsPage } from '../pages/tabs/tabs';
 import { StockpileData } from '../providers/stockpile-data';
 import { UserData } from '../providers/user-data';
 
-
 @Component({
   templateUrl: './app.html'
 })
 export class MyApp {
+  @ViewChild(Nav) nav: Nav;
   rootPage: any;
 
   constructor(
     public platform: Platform,
     public stockpileData: StockpileData,
-    public userData: UserData
+    public userData: UserData,
+    public menuCtrl: MenuController
   ) { }
 
   ngOnInit() {
@@ -29,13 +30,23 @@ export class MyApp {
           this.rootPage = LoginPage;
         }
 
-        this.platform.ready().then(() => {
-          // Okay, so the platform is ready and our plugins are available.
-          // Here you can do any higher level native things you might need.
-          StatusBar.styleDefault();
-          Splashscreen.hide();
-        });
+        this.initializeApp();
       });
     });
+  }
+
+  initializeApp() {
+    this.platform.ready().then(() => {
+      // Okay, so the platform is ready and our plugins are available.
+      // Here you can do any higher level native things you might need.
+      StatusBar.styleDefault();
+      Splashscreen.hide();
+    });
+  }
+
+  logout() {
+    this.userData.logout();
+    this.menuCtrl.close();
+    this.nav.setRoot(LoginPage);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,25 +3,39 @@ import { Platform } from 'ionic-angular';
 import { StatusBar, Splashscreen } from 'ionic-native';
 
 import { LoginPage } from '../pages/login/login';
+import { TabsPage } from '../pages/tabs/tabs';
 import { StockpileData } from '../providers/stockpile-data';
+import { UserData } from '../providers/user-data';
 
 
 @Component({
   templateUrl: './app.html'
 })
 export class MyApp {
-  rootPage = LoginPage;
+  rootPage: any;
 
-  constructor(platform: Platform, public stockpileData: StockpileData) {
-    platform.ready().then(() => {
-      // Okay, so the platform is ready and our plugins are available.
-      // Here you can do any higher level native things you might need.
-      StatusBar.styleDefault();
-      Splashscreen.hide();
-    });
-  }
+  constructor(
+    public platform: Platform,
+    public stockpileData: StockpileData,
+    public userData: UserData
+  ) { }
 
   ngOnInit() {
-    this.stockpileData.initHal();
+    this.stockpileData.initHal().then(() => {
+      this.userData.isLoggedIn().then(loggedIn => {
+        if (loggedIn) {
+          this.rootPage = TabsPage;
+        } else {
+          this.rootPage = LoginPage;
+        }
+
+        this.platform.ready().then(() => {
+          // Okay, so the platform is ready and our plugins are available.
+          // Here you can do any higher level native things you might need.
+          StatusBar.styleDefault();
+          Splashscreen.hide();
+        });
+      });
+    });
   }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,19 @@
-<ion-nav [root]="rootPage"></ion-nav>
+<ion-menu [content]="content">
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Menu</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <button ion-item (click)="logout()">
+        Logout
+      </button>
+    </ion-list>
+  </ion-content>
+
+</ion-menu>
+
+<!-- Disable swipe-to-go-back because it's poor UX to combine STGB with side menus -->
+<ion-nav [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,9 @@
 import { NgModule, ErrorHandler } from '@angular/core';
 import { IonicApp, IonicModule, IonicErrorHandler } from 'ionic-angular';
 import { CloudSettings, CloudModule } from '@ionic/cloud-angular';
+import { Http } from '@angular/http';
+import { Storage } from '@ionic/storage';
+import { AuthHttp, AuthConfig } from 'angular2-jwt';
 import { HalModule } from 'ng-hal';
 import { MyApp } from './app.component';
 
@@ -15,6 +18,14 @@ import { TabsPage } from '../pages/tabs/tabs';
 import { InventoryData } from '../providers/inventory-data';
 import { StockpileData } from '../providers/stockpile-data';
 import { UserData } from '../providers/user-data';
+
+let storage = new Storage();
+
+export function getAuthHttp(http) {
+  return new AuthHttp(new AuthConfig({
+    tokenGetter: (() => storage.get('id_token')),
+  }), http);
+}
 
 const cloudSettings: CloudSettings = {
   'core': {
@@ -51,6 +62,12 @@ const cloudSettings: CloudSettings = {
     RentalDetailsPage,
     TabsPage
   ],
-  providers: [{provide: ErrorHandler, useClass: IonicErrorHandler}, InventoryData, StockpileData, UserData]
+  providers: [
+    { provide: ErrorHandler, useClass: IonicErrorHandler },
+    InventoryData,
+    StockpileData,
+    UserData,
+    { provide: AuthHttp, useFactory: getAuthHttp, deps: [Http] }
+  ]
 })
 export class AppModule {}

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { PlatformMock, StockpileDataMock, UserDataMock } from '../mocks';
+import { PlatformMock, StockpileDataMock, UserDataMock, MenuMock, NavMock } from '../mocks';
 import { MyApp } from './app.component';
 import { LoginPage } from '../pages/login/login';
 import { TabsPage } from '../pages/tabs/tabs';
@@ -9,7 +9,8 @@ let instance: any = null;
 describe('Root Component', () => {
 
   beforeEach(() => {
-    instance = new MyApp((<any> new PlatformMock), (<any> new StockpileDataMock), (<any> new UserDataMock));
+    instance = new MyApp((<any> new PlatformMock), (<any> new StockpileDataMock), (<any> new UserDataMock), (<any> new MenuMock));
+    instance.nav = (<any> new NavMock);
   });
 
   it('is created', () => {
@@ -40,4 +41,14 @@ describe('Root Component', () => {
     tick();
     expect(instance.rootPage).toEqual(TabsPage);
   }));
+
+  it('calls logout(), closes side menu and sets nav root to LoginPage', () => {
+    spyOn(instance.userData, 'logout');
+    spyOn(instance.menuCtrl, 'close');
+    spyOn(instance.nav, 'setRoot');
+    instance.logout();
+    expect(instance.userData.logout).toHaveBeenCalled();
+    expect(instance.menuCtrl.close).toHaveBeenCalled();
+    expect(instance.nav.setRoot).toHaveBeenCalledWith(LoginPage);
+  });
 });

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,26 +1,43 @@
-import { PlatformMock, StockpileDataMock } from '../mocks';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { PlatformMock, StockpileDataMock, UserDataMock } from '../mocks';
 import { MyApp } from './app.component';
 import { LoginPage } from '../pages/login/login';
+import { TabsPage } from '../pages/tabs/tabs';
 
 let instance: any = null;
 
 describe('Root Component', () => {
 
   beforeEach(() => {
-    instance = new MyApp((<any> new PlatformMock), (<any> new StockpileDataMock));
+    instance = new MyApp((<any> new PlatformMock), (<any> new StockpileDataMock), (<any> new UserDataMock));
   });
 
   it('is created', () => {
     expect(instance).toBeTruthy();
   });
 
-  it('initialises with a root page of LoginPage', () => {
-    expect(instance.rootPage).toBe(LoginPage);
-  });
-
-  it('calls stockpileData.initHal()', () => {
-    spyOn(instance.stockpileData, 'initHal');
+  it('calls initHal(), isLoggedIn and platform.ready() in ngOnInit', fakeAsync(() => {
+    spyOn(instance.stockpileData, 'initHal').and.callThrough();
+    spyOn(instance.userData, 'isLoggedIn').and.callThrough();
+    spyOn(instance.platform, 'ready').and.callThrough();
     instance.ngOnInit();
+    tick();
     expect(instance.stockpileData.initHal).toHaveBeenCalled();
-  });
+    expect(instance.userData.isLoggedIn).toHaveBeenCalled();
+    expect(instance.platform.ready).toHaveBeenCalled();
+  }));
+
+  it('sets LoginPage as a root page if user is not logged in', fakeAsync(() => {
+    instance.userData.loggedIn = false;
+    instance.ngOnInit();
+    tick();
+    expect(instance.rootPage).toEqual(LoginPage);
+  }));
+
+  it('sets TabsPage as a root page if user is logged in', fakeAsync(() => {
+    instance.userData.loggedIn = true;
+    instance.ngOnInit();
+    tick();
+    expect(instance.rootPage).toEqual(TabsPage);
+  }));
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,4 +3,17 @@ export class Actions {
   public static return = 'Return';
   public static add = 'Add';
   public static edit = 'Edit';
+};
+
+export const ApiUrl = 'https://stockpile.adamvig.com/api';
+
+export class Links {
+  public static authenticate = 'authenticate';
+  public static createitem = 'createitem';
+  public static createorganization = 'createorganization';
+  public static createrental = 'createrental';
+  public static createuser = 'createuser';
+  public static getallitems = 'getallitems';
+  public static getallrentals = 'getallrentals';
+  public static getallusers = 'getallusers';
 }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -99,6 +99,16 @@ export class NavParamsMock {
   }
 }
 
+export class StorageMock {
+  public get(): any {
+    return Promise.resolve();
+  }
+
+  public set(): any {
+    return Promise.resolve();
+  }
+}
+
 export class NavigatorMock {
   hal = {};
 
@@ -146,12 +156,29 @@ export class InventoryDataMock {
 }
 
 export class StockpileDataMock {
-  public initHal(): any { }
+  public initHal(): any {
+    return Promise.resolve();
+  }
+
+  public getUrl(): any { }
 }
 
 export class UserDataMock {
+  resolve: boolean;
+  loggedIn: boolean;
+
   public login(): any {
-    return Observable.fromPromise(Promise.resolve());
+    return new Promise((resolve, reject) => {
+      if (this.resolve) {
+        resolve();
+      } else {
+        reject();
+      }
+    });
+  }
+
+  public isLoggedIn(): any {
+    return Promise.resolve(this.loggedIn);
   }
 }
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -177,6 +177,8 @@ export class UserDataMock {
     });
   }
 
+  public logout(): any { }
+
   public isLoggedIn(): any {
     return Promise.resolve(this.loggedIn);
   }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -103,11 +103,7 @@ export class NavigatorMock {
   hal = {};
 
   public get(): any {
-    let promise = new Promise((resolve, reject) => {
-      resolve(this.hal);
-    });
-
-    return Observable.fromPromise(promise);
+    return Observable.fromPromise(Promise.resolve(this.hal));
   }
 }
 
@@ -117,35 +113,35 @@ export class InventoryDataMock {
   categories = TestData.categories;
 
   public addItem(): any {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   public getItem(): any {
-    return Promise.resolve(this.item);
+    return Observable.fromPromise(Promise.resolve(this.item));
   }
 
   public editItem(): any {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   public deleteItem(): any {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   public rent(): any {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   public return(): any {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   public getConditions(): any {
-    return Promise.resolve(this.conditions);
+    return Observable.fromPromise(Promise.resolve(this.conditions));
   }
 
   public getCategories(): any {
-    return Promise.resolve(this.categories);
+    return Observable.fromPromise(Promise.resolve(this.categories));
   }
 }
 
@@ -155,7 +151,7 @@ export class StockpileDataMock {
 
 export class UserDataMock {
   public login(): any {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 }
 

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-navbar>
+    <button ion-button menuToggle>
+      <ion-icon name="menu"></ion-icon>
+    </button>
     <ion-title>Scan</ion-title>
   </ion-navbar>
 </ion-header>

--- a/src/pages/inventory/inventory.html
+++ b/src/pages/inventory/inventory.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-navbar>
+    <button ion-button menuToggle>
+      <ion-icon name="menu"></ion-icon>
+    </button>
     <ion-title>View</ion-title>
   </ion-navbar>
 </ion-header>

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -28,18 +28,18 @@ export class ItemPage {
     this.action = this.navParams.get('action');
 
     if (this.action === this.actions.edit) {
-      this.inventoryData.getItem(this.tag).then(
+      this.inventoryData.getItem(this.tag).subscribe(
         item => this.item = item,
         err => console.error(err)
       );
     }
 
-    this.inventoryData.getConditions().then(
+    this.inventoryData.getConditions().subscribe(
       conditions => this.conditions = conditions,
       err => console.log(err)
     );
 
-    this.inventoryData.getCategories().then(
+    this.inventoryData.getCategories().subscribe(
       categories => this.categories = categories,
       err => console.log(err)
     );
@@ -48,12 +48,12 @@ export class ItemPage {
   onSave(form: NgForm) {
     if (form.valid) {
       if (this.action === this.actions.add) {
-        this.inventoryData.addItem(this.item, this.tag).then(
+        this.inventoryData.addItem(this.item, this.tag).subscribe(
           success => this.navCtrl.pop(),
           err => console.error(err)
         );
       } else if (this.action === this.actions.edit) {
-        this.inventoryData.editItem(this.item, this.tag).then(
+        this.inventoryData.editItem(this.item, this.tag).subscribe(
           success => this.navCtrl.pop(),
           err => console.error(err)
         );
@@ -62,7 +62,7 @@ export class ItemPage {
   }
 
   onDelete() {
-    this.inventoryData.deleteItem(this.tag).then(
+    this.inventoryData.deleteItem(this.tag).subscribe(
       success => this.navCtrl.pop(),
       err => console.error(err)
     );

--- a/src/pages/login/login.spec.ts
+++ b/src/pages/login/login.spec.ts
@@ -36,6 +36,7 @@ describe('Login Page', () => {
   it('changes root nav to TabsPage onLogin() if form is valid', fakeAsync(() => {
     instance.login.email = TestData.credentials.email;
     instance.login.password = TestData.credentials.password;
+    instance.userData.resolve = true;
     spyOn(instance.navCtrl, 'setRoot');
     fixture.detectChanges();
     fixture.whenStable().then(() => {
@@ -44,6 +45,22 @@ describe('Login Page', () => {
       instance.onLogin(form);
       tick();
       expect(instance.navCtrl.setRoot).toHaveBeenCalledWith(TabsPage);
+    });
+  }));
+
+  it('resets password and logs error if error', fakeAsync(() => {
+    instance.login.email = TestData.credentials.email;
+    instance.login.password = TestData.credentials.password;
+    instance.userData.resolve = false;
+    spyOn(console, 'error');
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      let form: NgForm = fixture.debugElement.children[0].injector.get(NgForm);
+      instance.onLogin(form);
+      tick();
+      expect(instance.login.password).toEqual('');
+      expect(console.error).toHaveBeenCalled();
     });
   }));
 

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -19,9 +19,10 @@ export class LoginPage {
     this.submitted = true;
 
     if (form.valid) {
-      this.userData.login(this.login.email, this.login.password).then(
-        success => this.navCtrl.setRoot(TabsPage),
-        err => console.error(err));
+      this.userData.login(this.login.email, this.login.password).subscribe(
+        data => this.navCtrl.setRoot(TabsPage),
+        err => console.log(err)
+      );
     }
   }
 }

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -19,9 +19,12 @@ export class LoginPage {
     this.submitted = true;
 
     if (form.valid) {
-      this.userData.login(this.login.email, this.login.password).subscribe(
+      this.userData.login(this.login.email, this.login.password).then(
         data => this.navCtrl.setRoot(TabsPage),
-        err => console.log(err)
+        err => {
+          this.login.password = '';
+          console.error(err);
+        }
       );
     }
   }

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -27,7 +27,7 @@ export class RentalDetailsPage {
     this.submitted = true;
 
     if (form.valid) {
-      this.inventoryData.rent(this.items, this.details).then(
+      this.inventoryData.rent(this.items, this.details).subscribe(
         success => this.navCtrl.popToRoot(),
         err => console.error(err)
       );

--- a/src/pages/rental/rental.ts
+++ b/src/pages/rental/rental.ts
@@ -30,7 +30,7 @@ export class RentalPage {
   }
 
   onAdd() {
-    this.inventoryData.getItem(this.tag).then(
+    this.inventoryData.getItem(this.tag).subscribe(
       item => this.items.push(item),
       err => console.error(err)
     );
@@ -52,7 +52,7 @@ export class RentalPage {
   }
 
   onReturn() {
-    this.inventoryData.return(this.items).then(
+    this.inventoryData.return(this.items).subscribe(
       data => this.navCtrl.pop(),
       err => console.log(err)
     );

--- a/src/providers/inventory-data.spec.ts
+++ b/src/providers/inventory-data.spec.ts
@@ -15,56 +15,56 @@ describe('InventoryData Provider', () => {
   });
 
   it('returns an empty promise on getItem()', () => {
-    inventoryData.getItem(TestData.item.tag).then(
+    inventoryData.getItem(TestData.item.tag).subscribe(
       item => expect(item).toEqual(TestData.item),
       err => expect(false)
     );
   });
 
   it('returns an empty promise on addItem()', () => {
-    inventoryData.addItem(TestData.item, TestData.item.tag).then(
+    inventoryData.addItem(TestData.item, TestData.item.tag).subscribe(
       success => expect(true),
       err => expect(false)
     );
   });
 
   it('returns an empty promise on editItem()', () => {
-    inventoryData.editItem(TestData.item, TestData.item.tag).then(
+    inventoryData.editItem(TestData.item, TestData.item.tag).subscribe(
       success => expect(true),
       err => expect(false)
     );
   });
 
   it('returns an empty promise on deleteItem()', () => {
-    inventoryData.deleteItem(TestData.item.tag).then(
+    inventoryData.deleteItem(TestData.item.tag).subscribe(
       success => expect(true),
       err => expect(false)
     );
   });
 
   it('returns an empty promise on rent()', () => {
-    inventoryData.rent(TestData.items, TestData.details).then(
+    inventoryData.rent(TestData.items, TestData.details).subscribe(
       success => expect(true),
       err => expect(false)
     );
   });
 
   it('returns an empty promise on return()', () => {
-    inventoryData.return(TestData.items).then(
+    inventoryData.return(TestData.items).subscribe(
       success => expect(true),
       err => expect(false)
     );
   });
 
   it('returns categories on getCategories()', () => {
-    inventoryData.getCategories().then(
+    inventoryData.getCategories().subscribe(
       categories => expect(categories).toEqual(TestData.categories),
       err => expect(false)
     );
   });
 
   it('returns conditions on getConditions()', () => {
-    inventoryData.getConditions().then(
+    inventoryData.getConditions().subscribe(
       conditions => expect(conditions).toEqual(TestData.conditions),
       err => expect(false)
     );

--- a/src/providers/inventory-data.ts
+++ b/src/providers/inventory-data.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { TestData } from '../test-data';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/Rx';
 
 @Injectable()
 export class InventoryData {
@@ -7,34 +9,34 @@ export class InventoryData {
   constructor() { }
 
   getItem(tag: string) {
-    return Promise.resolve(TestData.item);
+    return Observable.fromPromise(Promise.resolve(TestData.item));
   }
 
   addItem(item: Object, tag: string) {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   editItem(item: Object, tag: string) {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   deleteItem(tag: string) {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   rent(items: Array<Object>, details: Object) {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   return(items: Array<Object>) {
-    return Promise.resolve();
+    return Observable.fromPromise(Promise.resolve());
   }
 
   getConditions() {
-    return Promise.resolve(TestData.conditions);
+    return Observable.fromPromise(Promise.resolve(TestData.conditions));
   }
 
   getCategories() {
-    return Promise.resolve(TestData.categories);
+    return Observable.fromPromise(Promise.resolve(TestData.categories));
   }
 }

--- a/src/providers/stockpile-data.spec.ts
+++ b/src/providers/stockpile-data.spec.ts
@@ -2,7 +2,6 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { NavigatorMock } from '../mocks';
 
 import { StockpileData } from './stockpile-data';
-import { ApiUrl } from '../constants';
 
 let stockpileData: StockpileData = null;
 

--- a/src/providers/stockpile-data.spec.ts
+++ b/src/providers/stockpile-data.spec.ts
@@ -2,6 +2,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { NavigatorMock } from '../mocks';
 
 import { StockpileData } from './stockpile-data';
+import { ApiUrl } from '../constants';
 
 let stockpileData: StockpileData = null;
 
@@ -15,8 +16,11 @@ describe('StockpileData Provider', () => {
     expect(stockpileData).not.toBeNull();
   });
 
-  it('gets a hal doc on init()', fakeAsync(() => {
-    stockpileData.initHal();
+  it('gets a hal doc on init() and returns a promise', fakeAsync(() => {
+    stockpileData.initHal().then(
+      success => expect(true).toBeTruthy(),
+      err => expect(false).toBeTruthy()
+    );
     tick();
     expect(stockpileData.hal).toBeTruthy();
   }));

--- a/src/providers/stockpile-data.ts
+++ b/src/providers/stockpile-data.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Navigator, HalDocument } from 'ng-hal';
+import { ApiUrl } from '../constants';
 
 @Injectable()
 export class StockpileData {
@@ -8,8 +9,20 @@ export class StockpileData {
   constructor(public navigator: Navigator) { }
 
   initHal() {
-    this.navigator
-      .get('https://stockpile.adamvig.com/api')
-      .subscribe((doc: HalDocument) => this.hal = doc);
+    return new Promise((resolve, reject) => {
+      this.navigator
+        .get(ApiUrl)
+        .subscribe((doc: HalDocument) => {
+          this.hal = doc;
+          resolve();
+        });
+    });
+  }
+
+  getUrl(key: string) {
+    // Ugly solution to extract endpoint from the HAL object.
+    // The ng-hal library does not support this out of the box,
+    // but they are planning on implementing it
+    return ApiUrl + this.hal.resource.allLinks()[key][0].href;
   }
 }

--- a/src/providers/user-data.spec.ts
+++ b/src/providers/user-data.spec.ts
@@ -57,6 +57,12 @@ describe('UserData Provider', () => {
     });
   })));
 
+  it('deletes id_token on logout()', inject([UserData, Storage], (userData: UserData, storage: Storage) => {
+    spyOn(userData.storage, 'remove');
+    userData.logout();
+    expect(userData.storage.remove).toHaveBeenCalledWith('id_token');
+  }));
+
   it('returns a promise on isLoggedIn', inject([UserData], (userData: UserData) => {
     userData.isLoggedIn().then(
       data => expect(data).toBeTruthy(),

--- a/src/providers/user-data.spec.ts
+++ b/src/providers/user-data.spec.ts
@@ -1,21 +1,66 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { async } from '@angular/core/testing';
+import { BaseRequestOptions, Http, HttpModule, Response, ResponseOptions } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+import { Storage } from '@ionic/storage';
+import { AuthHttp, AuthConfig } from 'angular2-jwt';
+
 import { UserData } from './user-data';
 import { TestData } from '../test-data';
-
-let userData: UserData = null;
+import { StockpileData } from './stockpile-data';
+import { StockpileDataMock, StorageMock } from '../mocks';
 
 describe('UserData Provider', () => {
 
   beforeEach(() => {
-    userData = new UserData();
+    TestBed.configureTestingModule({
+      providers: [
+        UserData,
+        { provide: Storage, useClass: StorageMock },
+        { provide: StockpileData, useClass: StockpileDataMock },
+        MockBackend,
+        BaseRequestOptions,
+        {
+          provide: Http,
+          useFactory: (backendInstance: MockBackend, defaultOptions: BaseRequestOptions) => {
+            return new Http(backendInstance, defaultOptions);
+          },
+          deps: [MockBackend, BaseRequestOptions]
+        },
+        {
+          provide: AuthHttp,
+          useFactory: (http) => {
+            return new AuthHttp(new AuthConfig({
+              noJwtError: true
+            }), http);
+          },
+          deps: [Http]
+        }
+      ],
+      imports: [
+        HttpModule
+      ]
+    });
   });
 
-  it('is created', () => {
+  it('is created', inject([UserData], (userData: UserData) => {
     expect(userData).not.toBeNull();
-  });
+  }));
 
-  it('returns an empty promise on login()', () => {
-    userData.login(TestData.credentials.email, TestData.credentials.password).then(
-      success => expect(true),
-      err => expect(false));
-  });
+  it('returns a login response on login()', async(inject([UserData, MockBackend], (userData: UserData, mockBackend: MockBackend) => {
+    mockBackend.connections.subscribe(
+      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.loginResponse) })))
+    );
+
+    userData.login(TestData.credentials.email, TestData.credentials.password).then(res => {
+      expect(res).toEqual(TestData.loginResponse);
+    });
+  })));
+
+  it('returns a promise on isLoggedIn', inject([UserData], (userData: UserData) => {
+    userData.isLoggedIn().then(
+      data => expect(data).toBeTruthy(),
+      err => expect(false).toBeTruthy()
+    );
+  }));
 });

--- a/src/providers/user-data.ts
+++ b/src/providers/user-data.ts
@@ -1,11 +1,50 @@
 import { Injectable } from '@angular/core';
+import { Response, Http } from '@angular/http';
+import { Storage } from '@ionic/storage';
+import { AuthHttp, tokenNotExpired } from 'angular2-jwt';
+import { StockpileData } from './stockpile-data';
+import { Links } from '../constants';
+import 'rxjs/add/operator/map';
 
 @Injectable()
 export class UserData {
+  storage = new Storage();
 
-  constructor() { }
+  constructor(
+    public authHttp: AuthHttp,
+    public stockpileData: StockpileData,
+    public http: Http
+  ) { }
 
   login(email: string, password: string) {
-    return Promise.resolve();
+    let creds = {
+      'email': email,
+      'password': password
+    };
+
+    return new Promise((resolve, reject) => {
+      this.http.post(this.stockpileData.getUrl(Links.authenticate), creds)
+        .map(this.extractData)
+        .subscribe(
+          data => {
+            this.storage.set('id_token', data.token);
+            resolve(data);
+          },
+          err => reject(err)
+        );
+    });
+  }
+
+  isLoggedIn() {
+    return new Promise((resolve, reject) => {
+      this.storage.get('id_token').then(token => {
+        resolve(tokenNotExpired(null, token));
+      });
+    });
+  }
+
+  private extractData(res: Response) {
+    let body = res.json();
+    return body || { };
   }
 }

--- a/src/providers/user-data.ts
+++ b/src/providers/user-data.ts
@@ -35,6 +35,10 @@ export class UserData {
     });
   }
 
+  logout() {
+    this.storage.remove('id_token');
+  }
+
   isLoggedIn() {
     return new Promise((resolve, reject) => {
       this.storage.get('id_token').then(token => {

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -39,4 +39,10 @@ export class TestData {
     email: 'luke@rebellion.com',
     password: 'yodarocks'
   };
+
+  public static loginResponse = {
+    id: 1,
+    token: '987234.sdf0982347234.hjgsdf89234',
+    message: 'organization credentials are valid'
+  };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -14,7 +14,7 @@ import { getTestBed, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams } from 'ionic-angular';
 import { NgForm } from '@angular/forms';
-import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock } from './mocks';
+import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock, UserDataMock } from './mocks';
 import { InventoryData } from './providers/inventory-data';
 import { UserData } from './providers/user-data';
 
@@ -59,12 +59,13 @@ export class TestUtils {
       ],
       providers: [
         App, Form, Keyboard, DomController, MenuController, GestureController,
-        NgForm, InventoryData, UserData,
+        NgForm,
         { provide: Platform, useClass: PlatformMock },
         { provide: Config, useClass: ConfigMock },
         { provide: NavController, useClass: NavMock },
         { provide: NavParams, useClass: NavParamsMock },
-        { provide: InventoryData, useClass: InventoryDataMock }
+        { provide: InventoryData, useClass: InventoryDataMock },
+        { provide: UserData, useClass: UserDataMock }
       ],
       imports: [
         FormsModule,


### PR DESCRIPTION
Closes #15 

Login now sends the credentials to the api to authenticate. It stores the token in storage and the `angular2-jwt` library will automatically add it in the auth header for every request to the api. The call inside login uses `http` instead of angular2-jwt's `authHttp` because this is the only call where we don't want a header.

Every time a user opens the app, we verify if the token is expired. If not, we go to the TabsPage, if yes, we go to LoginPage.

I also added a logout button in a left side menu. Eventually, we might want to put some info about the user and organization in this menu.