### PR TITLE
Add datetime picker for dates

### DIFF
--- a/src/pages/rental-details/rental-details.html
+++ b/src/pages/rental-details/rental-details.html
@@ -11,12 +11,14 @@
 
       <ion-item>
 				<ion-label floating color="primary">Start Date</ion-label>
+        <!-- Displays date in the following format: Sun 01 Jan, 2017 -->
         <ion-datetime displayFormat="DDD D MMM, YYYY" pickerFormat="DD MMM YYYY" [(ngModel)]="details.startDate"  name="startDate" #date="ngModel" required>
         </ion-datetime>
 			</ion-item>
 
       <ion-item>
 				<ion-label floating color="primary">Return Date</ion-label>
+        <!-- Displays date in the following format: Sun 01 Jan, 2017 -->
         <ion-datetime displayFormat="DDD D MMM, YYYY" pickerFormat="DD MMM YYYY" [(ngModel)]="details.endDate"  name="endDate" #date="ngModel" required>
         </ion-datetime>
 			</ion-item>

--- a/src/pages/rental-details/rental-details.html
+++ b/src/pages/rental-details/rental-details.html
@@ -11,14 +11,14 @@
 
       <ion-item>
 				<ion-label floating color="primary">Start Date</ion-label>
-				<ion-input [(ngModel)]="details.startDate" name="startDate" type="date" #date="ngModel" required>
-				</ion-input>
+        <ion-datetime displayFormat="DDD D MMM, YYYY" pickerFormat="DD MMM YYYY" [(ngModel)]="details.startDate"  name="startDate" #date="ngModel" required>
+        </ion-datetime>
 			</ion-item>
 
       <ion-item>
 				<ion-label floating color="primary">Return Date</ion-label>
-				<ion-input [(ngModel)]="details.endDate" name="endDate" type="date" #date="ngModel" required>
-				</ion-input>
+        <ion-datetime displayFormat="DDD D MMM, YYYY" pickerFormat="DD MMM YYYY" [(ngModel)]="details.endDate"  name="endDate" #date="ngModel" required>
+        </ion-datetime>
 			</ion-item>
 
       <ion-list-header>Scanned Items</ion-list-header>

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -21,6 +21,12 @@ export class RentalDetailsPage {
 
   ngOnInit() {
     this.items = this.navParams.get('items');
+
+    const today = new Date();
+    let tomorrow = new Date();
+    tomorrow.setDate(today.getDate() + 1);
+    this.details.startDate = today.toISOString();
+    this.details.endDate = tomorrow.toISOString();
   }
 
   onRent(form: NgForm) {

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -23,7 +23,7 @@ export class RentalDetailsPage {
     this.items = this.navParams.get('items');
 
     const today = new Date();
-    let tomorrow = new Date();
+    const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
     this.details.startDate = today.toISOString();
     this.details.endDate = tomorrow.toISOString();


### PR DESCRIPTION
Closes #74 

I added today's date as the default value for start date and tomorrow's date as the default value for return date to avoid the picker to start at 01/01/2017. We'll have to check with our clients if those dates make sense.