### PR TITLE
Add ui to filter and add new item properties

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { MyApp } from './app.component';
 
 import { HomePage } from '../pages/home/home';
 import { InventoryPage } from '../pages/inventory/inventory';
-import { ItemPage } from '../pages/item/item';
+import { ItemPage, ItemPopoverPage } from '../pages/item/item';
 import { LoginPage } from '../pages/login/login';
 import { RentalPage } from '../pages/rental/rental';
 import { RentalDetailsPage } from '../pages/rental-details/rental-details';
@@ -39,6 +39,7 @@ const cloudSettings: CloudSettings = {
     HomePage,
     InventoryPage,
     ItemPage,
+    ItemPopoverPage,
     LoginPage,
     RentalPage,
     RentalDetailsPage,
@@ -57,6 +58,7 @@ const cloudSettings: CloudSettings = {
     HomePage,
     InventoryPage,
     ItemPage,
+    ItemPopoverPage,
     LoginPage,
     RentalPage,
     RentalDetailsPage,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,8 @@ import { MyApp } from './app.component';
 
 import { HomePage } from '../pages/home/home';
 import { InventoryPage } from '../pages/inventory/inventory';
-import { ItemPage, ItemPopoverPage } from '../pages/item/item';
+import { ItemPage } from '../pages/item/item';
+import { ItemFilterPage } from '../pages/item-filter/item-filter';
 import { LoginPage } from '../pages/login/login';
 import { RentalPage } from '../pages/rental/rental';
 import { RentalDetailsPage } from '../pages/rental-details/rental-details';
@@ -39,7 +40,7 @@ const cloudSettings: CloudSettings = {
     HomePage,
     InventoryPage,
     ItemPage,
-    ItemPopoverPage,
+    ItemFilterPage,
     LoginPage,
     RentalPage,
     RentalDetailsPage,
@@ -58,7 +59,7 @@ const cloudSettings: CloudSettings = {
     HomePage,
     InventoryPage,
     ItemPage,
-    ItemPopoverPage,
+    ItemFilterPage,
     LoginPage,
     RentalPage,
     RentalDetailsPage,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,10 @@ export class Links {
   public static item = '/item';
   public static rental = '/rental';
 }
+
+export class ItemProperties {
+  public static brand = 'Brand';
+  public static model = 'Model';
+  public static category = 'Category';
+  public static status = 'Status';
+}

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -109,6 +109,20 @@ export class StorageMock {
   }
 }
 
+export class PopoverMock {
+  public create(): any {
+    return new PopoverMock;
+  }
+
+  public onDidDismiss(): any {}
+
+  public present(): any {}
+}
+
+export class ViewMock {
+  public dismiss(): any {}
+}
+
 export class NavigatorMock {
   hal = {};
 
@@ -118,7 +132,7 @@ export class NavigatorMock {
 }
 
 export class InventoryDataMock {
-  item = TestData.item;
+  item = TestData.apiItem;
   brands = TestData.brands;
   models = TestData.models;
   categories = TestData.categories;

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -92,7 +92,7 @@ export class MenuMock {
 }
 
 export class NavParamsMock {
-  param;
+  param: any;
 
   public get(): any {
     return this.param;

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -92,10 +92,10 @@ export class MenuMock {
 }
 
 export class NavParamsMock {
-  param: string = '';
+  param;
 
   public get(): any {
-    return String(this.param);
+    return this.param;
   }
 }
 
@@ -109,9 +109,9 @@ export class StorageMock {
   }
 }
 
-export class PopoverMock {
+export class ModalMock {
   public create(): any {
-    return new PopoverMock;
+    return new ModalMock;
   }
 
   public onDidDismiss(): any {}

--- a/src/pages/item-filter/item-filter.html
+++ b/src/pages/item-filter/item-filter.html
@@ -1,0 +1,27 @@
+<ion-header>
+  <ion-navbar>
+    <ion-buttons start>
+      <button ion-button (click)="dismiss()">Cancel</button>
+    </ion-buttons>
+
+    <ion-title>
+      Choose {{ type.toLowerCase() }}
+    </ion-title>
+  </ion-navbar>
+  <ion-toolbar>
+    <ion-searchbar [(ngModel)]="queryText"
+                   (ionInput)="getElements()"
+                   placeholder="Filter {{ type }}">
+    </ion-searchbar>
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-list>
+    <button ion-item detail-none *ngFor="let element of filteredElements" (click)="dismiss(element)">
+      {{ element.name }}
+    </button>
+    <button ion-item detail-none *ngIf="showNew" (click)="dismiss(queryText, true)">
+       Create new {{ type.toLowerCase() }}: {{ queryText }}
+    </button>
+  </ion-list>
+</ion-content>

--- a/src/pages/item-filter/item-filter.spec.ts
+++ b/src/pages/item-filter/item-filter.spec.ts
@@ -1,6 +1,5 @@
 import { TestData } from '../../test-data';
 import { ViewController } from 'ionic-angular';
-import { ItemProperties } from '../../constants';
 import { NavParamsMock } from '../../mocks';
 
 import { ItemFilterPage } from './item-filter';

--- a/src/pages/item-filter/item-filter.spec.ts
+++ b/src/pages/item-filter/item-filter.spec.ts
@@ -1,0 +1,52 @@
+import { TestData } from '../../test-data';
+import { ViewController } from 'ionic-angular';
+import { ItemProperties } from '../../constants';
+import { NavParamsMock } from '../../mocks';
+
+import { ItemFilterPage } from './item-filter';
+
+let itemFilterPage: ItemFilterPage = null;
+
+describe('ItemFilter Page', () => {
+
+  beforeEach(() => {
+    itemFilterPage = new ItemFilterPage(<any> new ViewController, <any> new NavParamsMock);
+  });
+
+  it('is created', () => {
+    expect(itemFilterPage).not.toBeNull();
+  });
+
+  it('gets navParam allElements and initializes filteredElements', () => {
+    itemFilterPage.navParams.param = TestData.brands;
+    itemFilterPage.ngOnInit();
+    expect(itemFilterPage.allElements).toEqual(TestData.brands);
+    expect(itemFilterPage.filteredElements).toEqual(TestData.brands)
+  });
+
+  it('gets navParam type', () => {
+    itemFilterPage.navParams.param = ItemProperties.brand;
+    itemFilterPage.ngOnInit();
+    expect(itemFilterPage.type).toEqual(ItemProperties.brand);
+  });
+
+  it('filters elements on getElements()', () => {
+    itemFilterPage.queryText = TestData.queryText;
+    itemFilterPage.allElements = TestData.brands;
+    itemFilterPage.getElements();
+    expect(itemFilterPage.filteredElements).toEqual(TestData.filteredBrands);
+  });
+
+  it('does not filter elements if queryText is empty', () => {
+    itemFilterPage.queryText = '';
+    itemFilterPage.allElements = TestData.brands;
+    itemFilterPage.getElements();
+    expect(itemFilterPage.filteredElements).toEqual(TestData.brands);
+  });
+
+  it('calls viewCtrl.dismiss on dismiss()', () => {
+    spyOn(itemFilterPage.viewCtrl, 'dismiss');
+    itemFilterPage.dismiss(TestData.brands[0]);
+    expect(itemFilterPage.viewCtrl.dismiss).toHaveBeenCalledWith(TestData.brands[0], false);
+  });
+});

--- a/src/pages/item-filter/item-filter.spec.ts
+++ b/src/pages/item-filter/item-filter.spec.ts
@@ -17,19 +17,6 @@ describe('ItemFilter Page', () => {
     expect(itemFilterPage).not.toBeNull();
   });
 
-  it('gets navParam allElements and initializes filteredElements', () => {
-    itemFilterPage.navParams.param = TestData.brands;
-    itemFilterPage.ngOnInit();
-    expect(itemFilterPage.allElements).toEqual(TestData.brands);
-    expect(itemFilterPage.filteredElements).toEqual(TestData.brands)
-  });
-
-  it('gets navParam type', () => {
-    itemFilterPage.navParams.param = ItemProperties.brand;
-    itemFilterPage.ngOnInit();
-    expect(itemFilterPage.type).toEqual(ItemProperties.brand);
-  });
-
   it('filters elements on getElements()', () => {
     itemFilterPage.queryText = TestData.queryText;
     itemFilterPage.allElements = TestData.brands;

--- a/src/pages/item-filter/item-filter.ts
+++ b/src/pages/item-filter/item-filter.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
-import { NavParams, ViewController, ModalController } from 'ionic-angular';
-
-import { ItemProperties } from '../../constants';
+import { NavParams, ViewController } from 'ionic-angular';
 
 @Component({
   selector: 'page-item-filter',
@@ -10,7 +8,7 @@ import { ItemProperties } from '../../constants';
 export class ItemFilterPage {
   allElements;
   filteredElements;
-  type: ItemProperties;
+  type;
   showNew: boolean = false;
   queryText: string = '';
 

--- a/src/pages/item-filter/item-filter.ts
+++ b/src/pages/item-filter/item-filter.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { NavParams, ViewController, ModalController } from 'ionic-angular';
+
+import { ItemProperties } from '../../constants';
+
+@Component({
+  selector: 'page-item-filter',
+  templateUrl: 'item-filter.html'
+})
+export class ItemFilterPage {
+  allElements;
+  filteredElements;
+  type: ItemProperties;
+  showNew: boolean = false;
+  queryText: string = '';
+
+  constructor(public viewCtrl: ViewController, public navParams: NavParams) { }
+
+  ngOnInit() {
+    this.allElements = this.navParams.get('elements');
+    this.type = this.navParams.get('type');
+    this.filteredElements = this.allElements;
+  }
+
+  getElements() {
+    this.filteredElements = this.allElements;
+    this.showNew = false;
+
+    if (this.queryText && this.queryText.trim() !== '') {
+      this.filteredElements = this.filteredElements.filter((element) => {
+        return (element.name.toLowerCase().indexOf(this.queryText.toLowerCase()) > -1);
+      });
+
+      const match = this.filteredElements.find((element) => {
+        return element.name.toLowerCase() === this.queryText.toLowerCase();
+      });
+
+      if (!match) {
+        this.showNew = true;
+      }
+    }
+  }
+
+  dismiss(element?: Object, isNew: boolean = false) {
+    this.viewCtrl.dismiss(element, isNew);
+  }
+}

--- a/src/pages/item/item.html
+++ b/src/pages/item/item.html
@@ -13,32 +13,24 @@
   <form #itemForm="ngForm" novalidate>
 		<ion-list no-line>
       <ion-item>
-				<ion-label floating color="primary">Brand</ion-label>
-				<ion-select [(ngModel)]="item.brandID" name="brand">
-          <ion-option *ngFor="let brand of brands" value="{{brand.id}}">{{brand.name}}</ion-option>
-        </ion-select>
-			</ion-item>
+        <ion-label stacked color="primary">Brand</ion-label>
+        <ion-input (click)="presentPopover($event, allBrands, itemProperties.brand)" value="{{ selectedBrand }}"></ion-input>
+      </ion-item>
 
       <ion-item>
-				<ion-label floating color="primary">Model</ion-label>
-				<ion-select [(ngModel)]="item.modelID" name="model">
-          <ion-option *ngFor="let model of models" value="{{model.id}}">{{model.name}}</ion-option>
-        </ion-select>
-			</ion-item>
+        <ion-label stacked color="primary">Model</ion-label>
+        <ion-input (click)="presentPopover($event, allModels, itemProperties.model)" value="{{ selectedModel }}"></ion-input>
+      </ion-item>
 
       <ion-item>
-				<ion-label floating color="primary">Category</ion-label>
-				<ion-select [(ngModel)]="item.categoryID" name="category">
-          <ion-option *ngFor="let category of categories" value="{{category.id}}">{{category.name}}</ion-option>
-        </ion-select>
-			</ion-item>
+        <ion-label stacked color="primary">Category</ion-label>
+        <ion-input (click)="presentPopover($event, allCategories, itemProperties.category)" value="{{ selectedCategory }}"></ion-input>
+      </ion-item>
 
       <ion-item>
-				<ion-label floating color="primary">Status</ion-label>
-				<ion-select [(ngModel)]="item.statusID" name="status">
-          <ion-option *ngFor="let status of statuses" value="{{status.id}}">{{status.name}}</ion-option>
-        </ion-select>
-			</ion-item>
+        <ion-label stacked color="primary">Status</ion-label>
+        <ion-input (click)="presentPopover($event, allStatuses, itemProperties.status)" value="{{ selectedStatus }}"></ion-input>
+      </ion-item>
 		</ion-list>
 
 		<button ion-button (click)="onSave(itemForm)" type="submit" block>Save</button>

--- a/src/pages/item/item.html
+++ b/src/pages/item/item.html
@@ -14,22 +14,22 @@
 		<ion-list no-line>
       <ion-item>
         <ion-label stacked color="primary">Brand</ion-label>
-        <ion-input (click)="presentModal($event, allBrands, itemProperties.brand)" value="{{ selectedBrand }}"></ion-input>
+        <ion-input (click)="presentModal(allBrands, itemProperties.brand)" value="{{ selectedBrand }}"></ion-input>
       </ion-item>
 
       <ion-item>
         <ion-label stacked color="primary">Model</ion-label>
-        <ion-input (click)="presentModal($event, allModels, itemProperties.model)" value="{{ selectedModel }}"></ion-input>
+        <ion-input (click)="presentModal(allModels, itemProperties.model)" value="{{ selectedModel }}"></ion-input>
       </ion-item>
 
       <ion-item>
         <ion-label stacked color="primary">Category</ion-label>
-        <ion-input (click)="presentModal($event, allCategories, itemProperties.category)" value="{{ selectedCategory }}"></ion-input>
+        <ion-input (click)="presentModal(allCategories, itemProperties.category)" value="{{ selectedCategory }}"></ion-input>
       </ion-item>
 
       <ion-item>
         <ion-label stacked color="primary">Status</ion-label>
-        <ion-input (click)="presentModal($event, allStatuses, itemProperties.status)" value="{{ selectedStatus }}"></ion-input>
+        <ion-input (click)="presentModal(allStatuses, itemProperties.status)" value="{{ selectedStatus }}"></ion-input>
       </ion-item>
 		</ion-list>
 

--- a/src/pages/item/item.html
+++ b/src/pages/item/item.html
@@ -14,22 +14,22 @@
 		<ion-list no-line>
       <ion-item>
         <ion-label stacked color="primary">Brand</ion-label>
-        <ion-input (click)="presentPopover($event, allBrands, itemProperties.brand)" value="{{ selectedBrand }}"></ion-input>
+        <ion-input (click)="presentModal($event, allBrands, itemProperties.brand)" value="{{ selectedBrand }}"></ion-input>
       </ion-item>
 
       <ion-item>
         <ion-label stacked color="primary">Model</ion-label>
-        <ion-input (click)="presentPopover($event, allModels, itemProperties.model)" value="{{ selectedModel }}"></ion-input>
+        <ion-input (click)="presentModal($event, allModels, itemProperties.model)" value="{{ selectedModel }}"></ion-input>
       </ion-item>
 
       <ion-item>
         <ion-label stacked color="primary">Category</ion-label>
-        <ion-input (click)="presentPopover($event, allCategories, itemProperties.category)" value="{{ selectedCategory }}"></ion-input>
+        <ion-input (click)="presentModal($event, allCategories, itemProperties.category)" value="{{ selectedCategory }}"></ion-input>
       </ion-item>
 
       <ion-item>
         <ion-label stacked color="primary">Status</ion-label>
-        <ion-input (click)="presentPopover($event, allStatuses, itemProperties.status)" value="{{ selectedStatus }}"></ion-input>
+        <ion-input (click)="presentModal($event, allStatuses, itemProperties.status)" value="{{ selectedStatus }}"></ion-input>
       </ion-item>
 		</ion-list>
 

--- a/src/pages/item/item.spec.ts
+++ b/src/pages/item/item.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
 import { NgForm } from '@angular/forms';
-import { ViewController } from 'ionic-angular';
 import { TestUtils } from '../../test';
 import { TestData } from '../../test-data';
 import { Actions, ItemProperties } from '../../constants';
 import { ViewMock, NavParamsMock } from '../../mocks';
 
-import { ItemPage, ItemPopoverPage } from './item';
+import { ItemPage } from './item';
+import { ItemFilterPage } from '../item-filter/item-filter';
 
 let fixture: ComponentFixture<ItemPage> = null;
 let instance: any = null;
@@ -113,9 +113,9 @@ describe('Item Page', () => {
     });
   }));
 
-  it('creates a popover on presentPopover()', () => {
-    spyOn(instance.popoverCtrl, 'create').and.callThrough();
-    instance.presentPopover(null, TestData.brands, ItemProperties.brand);
-    expect(instance.popoverCtrl.create).toHaveBeenCalledWith(ItemPopoverPage, { elements: TestData.brands, type: ItemProperties.brand });
+  it('creates a modal on presentModal()', () => {
+    spyOn(instance.modalCtrl, 'create').and.callThrough();
+    instance.presentModal(null, TestData.brands, ItemProperties.brand);
+    expect(instance.modalCtrl.create).toHaveBeenCalledWith(ItemFilterPage, { elements: TestData.brands, type: ItemProperties.brand });
   });
 });

--- a/src/pages/item/item.spec.ts
+++ b/src/pages/item/item.spec.ts
@@ -3,7 +3,6 @@ import { NgForm } from '@angular/forms';
 import { TestUtils } from '../../test';
 import { TestData } from '../../test-data';
 import { Actions, ItemProperties } from '../../constants';
-import { ViewMock, NavParamsMock } from '../../mocks';
 
 import { ItemPage } from './item';
 import { ItemFilterPage } from '../item-filter/item-filter';

--- a/src/pages/item/item.spec.ts
+++ b/src/pages/item/item.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
 import { NgForm } from '@angular/forms';
+import { ViewController } from 'ionic-angular';
 import { TestUtils } from '../../test';
 import { TestData } from '../../test-data';
-import { Actions } from '../../constants';
+import { Actions, ItemProperties } from '../../constants';
+import { ViewMock, NavParamsMock } from '../../mocks';
 
-import { ItemPage } from './item';
+import { ItemPage, ItemPopoverPage } from './item';
 
 let fixture: ComponentFixture<ItemPage> = null;
 let instance: any = null;
@@ -38,19 +40,29 @@ describe('Item Page', () => {
   });
 
   it('gets item if action === \'Edit\'', fakeAsync(() => {
-    instance.inventoryData.item = TestData.item;
+    instance.inventoryData.item = TestData.apiItem;
     instance.navParams.param = Actions.edit;
     instance.ngOnInit();
     tick();
     expect(instance.item).toEqual(TestData.item);
+    expect(instance.selectedBrand).toEqual(TestData.apiItem.brand);
+    expect(instance.selectedModel).toEqual(TestData.apiItem.model);
+    expect(instance.selectedCategory).toEqual(TestData.apiItem.category);
+    expect(instance.selectedStatus).toEqual(TestData.apiItem.status);
   }));
 
-  it('gets conditions and categories', fakeAsync(() => {
+  it('gets brands, models, statuses and categories', fakeAsync(() => {
+    instance.inventoryData.brands = TestData.brands;
+    instance.inventoryData.models = TestData.models;
+    instance.inventoryData.statuses = TestData.statuses;
+    instance.inventoryData.categories = TestData.categories;
     instance.navParams.param = Actions.edit;
     instance.ngOnInit();
     tick();
-    expect(instance.statuses).toEqual(TestData.statuses);
-    expect(instance.categories).toEqual(TestData.categories);
+    expect(instance.allBrands).toEqual(TestData.brands);
+    expect(instance.allModels).toEqual(TestData.models);
+    expect(instance.allStatuses).toEqual(TestData.statuses);
+    expect(instance.allCategories).toEqual(TestData.categories);
   }));
 
   it('calls onSave() on click on save button', () => {
@@ -100,4 +112,10 @@ describe('Item Page', () => {
       expect(instance.navCtrl.pop).toHaveBeenCalled();
     });
   }));
+
+  it('creates a popover on presentPopover()', () => {
+    spyOn(instance.popoverCtrl, 'create').and.callThrough();
+    instance.presentPopover(null, TestData.brands, ItemProperties.brand);
+    expect(instance.popoverCtrl.create).toHaveBeenCalledWith(ItemPopoverPage, { elements: TestData.brands, type: ItemProperties.brand });
+  });
 });

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -96,7 +96,7 @@ export class ItemPage {
     );
   }
 
-  presentModal(event, elements, type) {
+  presentModal(elements, type) {
     let modal = this.modalCtrl.create(ItemFilterPage, {
       elements: elements,
       type: type

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController, NavParams, PopoverController, ViewController } from 'ionic-angular';
 
 import { InventoryData } from '../../providers/inventory-data';
-import { Actions } from '../../constants';
+import { Actions, ItemProperties } from '../../constants';
 
 @Component({
   selector: 'page-item',
@@ -11,49 +11,65 @@ import { Actions } from '../../constants';
 })
 export class ItemPage {
   actions = Actions;
+  itemProperties = ItemProperties;
   action: Actions = '';
   item: {brandID?: number, modelID?: number, categoryID?: number, statusID?: number, tag?: string} = {};
-  brands;
-  models;
-  statuses;
-  categories;
+  selectedBrand: string;
+  allBrands;
+  selectedModel: string;
+  allModels;
+  selectedStatus: string;
+  allStatuses;
+  selectedCategory: string;
+  allCategories;
 
   constructor(
     public navCtrl: NavController,
     public navParams: NavParams,
-    public inventoryData: InventoryData
+    public inventoryData: InventoryData,
+    public popoverCtrl: PopoverController
   ) { }
 
   ngOnInit() {
     this.item.tag = this.navParams.get('tag');
     this.action = this.navParams.get('action');
 
-    if (this.action === this.actions.edit) {
-      this.inventoryData.getItem(this.item.tag).subscribe(
-        item => this.item = item,
-        err => console.error(err)
-      );
-    }
-
     this.inventoryData.getBrands().subscribe(
-      brands => this.brands = brands,
+      brands => this.allBrands = brands,
       err => console.log(err)
     );
 
     this.inventoryData.getModels().subscribe(
-      models => this.models = models,
+      models => this.allModels = models,
       err => console.log(err)
     );
 
     this.inventoryData.getStatuses().subscribe(
-      statuses => this.statuses = statuses,
+      statuses => this.allStatuses = statuses,
       err => console.log(err)
     );
 
     this.inventoryData.getCategories().subscribe(
-      categories => this.categories = categories,
+      categories => this.allCategories = categories,
       err => console.log(err)
     );
+
+    if (this.action === this.actions.edit) {
+      this.inventoryData.getItem(this.item.tag).subscribe(
+        item => {
+          this.item.brandID = item.brandID;
+          this.item.modelID = item.modelID;
+          this.item.categoryID = item.categoryID;
+          this.item.statusID = item.statusID;
+          this.item.tag = item.tag;
+          this.selectedBrand = item.brand;
+          this.selectedModel = item.model;
+          this.selectedCategory = item.category;
+          this.selectedStatus = item.status;
+        },
+        err => console.error(err)
+      );
+    }
   }
 
   onSave(form: NgForm) {
@@ -77,5 +93,83 @@ export class ItemPage {
       success => this.navCtrl.pop(),
       err => console.error(err)
     );
+  }
+
+  presentPopover(event, elements, type) {
+    let popover = this.popoverCtrl.create(ItemPopoverPage, {
+      elements: elements,
+      type: type
+    });
+
+    popover.onDidDismiss(value => {
+      if (value) {
+        switch (type) {
+          case this.itemProperties.brand:
+            this.item.brandID = value.id;
+            this.selectedBrand = value.name;
+            break;
+          case this.itemProperties.model:
+            this.item.modelID = value.id;
+            this.selectedModel = value.name;
+            break;
+          case this.itemProperties.category:
+            this.item.categoryID = value.id;
+            this.selectedCategory = value.name;
+            break;
+          case this.itemProperties.status:
+            this.item.statusID = value.id;
+            this.selectedStatus = value.name;
+            break;
+        }
+      }
+    });
+
+    popover.present({
+      ev: event
+    });
+  }
+}
+
+@Component({
+  template: `
+  <ion-searchbar (ionInput)="getElements($event)" placeholder="Filter {{ type }}"></ion-searchbar>
+  <ion-list>
+    <button ion-item detail-none *ngFor="let element of filteredElements" (click)="elementSelected(element)">
+      {{ element.name }}
+    </button>
+  </ion-list>
+  `
+})
+export class ItemPopoverPage {
+  allElements;
+  filteredElements;
+  type: ItemProperties;
+
+  constructor(public viewCtrl: ViewController, public navParams: NavParams) { }
+
+  ngOnInit() {
+    if (this.navParams.data) {
+      this.allElements = this.navParams.data.elements;
+      this.type = this.navParams.data.type;
+    }
+  }
+
+  getElements(ev: any) {
+    // Reset items back to all of the items
+    this.filteredElements = this.allElements;
+
+    // set val to the value of the searchbar
+    const val = ev.target.value;
+
+    // if the value is an empty string don't filter the items
+    if (val && val.trim() !== '') {
+      this.filteredElements = this.filteredElements.filter((element) => {
+        return (element.name.toLowerCase().indexOf(val.toLowerCase()) > -1);
+      });
+    }
+  }
+
+  elementSelected(element: Object) {
+    this.viewCtrl.dismiss(element);
   }
 }

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -101,25 +101,66 @@ export class ItemPage {
       type: type
     });
 
-    popover.onDidDismiss(value => {
+    popover.onDidDismiss((value, addNew) => {
       if (value) {
-        switch (type) {
-          case this.itemProperties.brand:
-            this.item.brandID = value.id;
-            this.selectedBrand = value.name;
-            break;
-          case this.itemProperties.model:
-            this.item.modelID = value.id;
-            this.selectedModel = value.name;
-            break;
-          case this.itemProperties.category:
-            this.item.categoryID = value.id;
-            this.selectedCategory = value.name;
-            break;
-          case this.itemProperties.status:
-            this.item.statusID = value.id;
-            this.selectedStatus = value.name;
-            break;
+        if (addNew) {
+          switch (type) {
+            case this.itemProperties.brand:
+              this.inventoryData.addBrand(value.name).subscribe(
+                brand => {
+                  this.item.brandID = brand.id;
+                  this.selectedBrand = brand.name;
+                },
+                err => console.error(err)
+              );
+              break;
+            case this.itemProperties.model:
+              this.inventoryData.addModel(value.name).subscribe(
+                model => {
+                  this.item.modelID = model.id;
+                  this.selectedModel = model.name;
+                },
+                err => console.error(err)
+              );
+              break;
+            case this.itemProperties.category:
+              this.inventoryData.addCategory(value.name).subscribe(
+                category => {
+                  this.item.categoryID = category.id;
+                  this.selectedCategory = category.name;
+                },
+                err => console.error(err)
+              );
+              break;
+            case this.itemProperties.status:
+              this.inventoryData.addStatus(value.name).subscribe(
+                status => {
+                  this.item.statusID = status.id;
+                  this.selectedStatus = status.name;
+                },
+                err => console.error(err)
+              );
+              break;
+          }
+        } else {
+          switch (type) {
+            case this.itemProperties.brand:
+              this.item.brandID = value.id;
+              this.selectedBrand = value.name;
+              break;
+            case this.itemProperties.model:
+              this.item.modelID = value.id;
+              this.selectedModel = value.name;
+              break;
+            case this.itemProperties.category:
+              this.item.categoryID = value.id;
+              this.selectedCategory = value.name;
+              break;
+            case this.itemProperties.status:
+              this.item.statusID = value.id;
+              this.selectedStatus = value.name;
+              break;
+          }
         }
       }
     });
@@ -137,6 +178,9 @@ export class ItemPage {
     <button ion-item detail-none *ngFor="let element of filteredElements" (click)="elementSelected(element)">
       {{ element.name }}
     </button>
+    <button ion-item detail-none *ngIf="showAdd" (click)="elementSelected(input, true)">
+       New {{ type.toLowerCase() }}: {{ input }}
+    </button>
   </ion-list>
   `
 })
@@ -144,6 +188,8 @@ export class ItemPopoverPage {
   allElements;
   filteredElements;
   type: ItemProperties;
+  showAdd: boolean = false;
+  input: string;
 
   constructor(public viewCtrl: ViewController, public navParams: NavParams) { }
 
@@ -155,21 +201,25 @@ export class ItemPopoverPage {
   }
 
   getElements(ev: any) {
-    // Reset items back to all of the items
     this.filteredElements = this.allElements;
+    this.showAdd = false;
+    this.input = '';
 
-    // set val to the value of the searchbar
     const val = ev.target.value;
 
-    // if the value is an empty string don't filter the items
     if (val && val.trim() !== '') {
       this.filteredElements = this.filteredElements.filter((element) => {
         return (element.name.toLowerCase().indexOf(val.toLowerCase()) > -1);
       });
+
+      if (!this.filteredElements.includes(val.toLowerCase())) {
+        this.showAdd = true;
+        this.input = val;
+      }
     }
   }
 
-  elementSelected(element: Object) {
-    this.viewCtrl.dismiss(element);
+  elementSelected(element: Object, addNew: boolean = false) {
+    this.viewCtrl.dismiss(element, addNew);
   }
 }

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import { NavController, NavParams, PopoverController, ViewController } from 'ionic-angular';
+import { NavController, NavParams, ModalController } from 'ionic-angular';
 
 import { InventoryData } from '../../providers/inventory-data';
 import { Actions, ItemProperties } from '../../constants';
+import { ItemFilterPage } from '../item-filter/item-filter';
 
 @Component({
   selector: 'page-item',
@@ -27,7 +28,7 @@ export class ItemPage {
     public navCtrl: NavController,
     public navParams: NavParams,
     public inventoryData: InventoryData,
-    public popoverCtrl: PopoverController
+    public modalCtrl: ModalController
   ) { }
 
   ngOnInit() {
@@ -95,18 +96,18 @@ export class ItemPage {
     );
   }
 
-  presentPopover(event, elements, type) {
-    let popover = this.popoverCtrl.create(ItemPopoverPage, {
+  presentModal(event, elements, type) {
+    let modal = this.modalCtrl.create(ItemFilterPage, {
       elements: elements,
       type: type
     });
 
-    popover.onDidDismiss((value, addNew) => {
-      if (value) {
-        if (addNew) {
+    modal.onDidDismiss((element, isNew) => {
+      if (element) {
+        if (isNew) {
           switch (type) {
             case this.itemProperties.brand:
-              this.inventoryData.addBrand(value.name).subscribe(
+              this.inventoryData.addBrand(element.name).subscribe(
                 brand => {
                   this.item.brandID = brand.id;
                   this.selectedBrand = brand.name;
@@ -115,7 +116,7 @@ export class ItemPage {
               );
               break;
             case this.itemProperties.model:
-              this.inventoryData.addModel(value.name).subscribe(
+              this.inventoryData.addModel(element.name).subscribe(
                 model => {
                   this.item.modelID = model.id;
                   this.selectedModel = model.name;
@@ -124,7 +125,7 @@ export class ItemPage {
               );
               break;
             case this.itemProperties.category:
-              this.inventoryData.addCategory(value.name).subscribe(
+              this.inventoryData.addCategory(element.name).subscribe(
                 category => {
                   this.item.categoryID = category.id;
                   this.selectedCategory = category.name;
@@ -133,7 +134,7 @@ export class ItemPage {
               );
               break;
             case this.itemProperties.status:
-              this.inventoryData.addStatus(value.name).subscribe(
+              this.inventoryData.addStatus(element.name).subscribe(
                 status => {
                   this.item.statusID = status.id;
                   this.selectedStatus = status.name;
@@ -145,81 +146,26 @@ export class ItemPage {
         } else {
           switch (type) {
             case this.itemProperties.brand:
-              this.item.brandID = value.id;
-              this.selectedBrand = value.name;
+              this.item.brandID = element.id;
+              this.selectedBrand = element.name;
               break;
             case this.itemProperties.model:
-              this.item.modelID = value.id;
-              this.selectedModel = value.name;
+              this.item.modelID = element.id;
+              this.selectedModel = element.name;
               break;
             case this.itemProperties.category:
-              this.item.categoryID = value.id;
-              this.selectedCategory = value.name;
+              this.item.categoryID = element.id;
+              this.selectedCategory = element.name;
               break;
             case this.itemProperties.status:
-              this.item.statusID = value.id;
-              this.selectedStatus = value.name;
+              this.item.statusID = element.id;
+              this.selectedStatus = element.name;
               break;
           }
         }
       }
-    });
+   });
 
-    popover.present({
-      ev: event
-    });
-  }
-}
-
-@Component({
-  template: `
-  <ion-searchbar (ionInput)="getElements($event)" placeholder="Filter {{ type }}"></ion-searchbar>
-  <ion-list>
-    <button ion-item detail-none *ngFor="let element of filteredElements" (click)="elementSelected(element)">
-      {{ element.name }}
-    </button>
-    <button ion-item detail-none *ngIf="showAdd" (click)="elementSelected(input, true)">
-       New {{ type.toLowerCase() }}: {{ input }}
-    </button>
-  </ion-list>
-  `
-})
-export class ItemPopoverPage {
-  allElements;
-  filteredElements;
-  type: ItemProperties;
-  showAdd: boolean = false;
-  input: string;
-
-  constructor(public viewCtrl: ViewController, public navParams: NavParams) { }
-
-  ngOnInit() {
-    if (this.navParams.data) {
-      this.allElements = this.navParams.data.elements;
-      this.type = this.navParams.data.type;
-    }
-  }
-
-  getElements(ev: any) {
-    this.filteredElements = this.allElements;
-    this.showAdd = false;
-    this.input = '';
-
-    const val = ev.target.value;
-
-    if (val && val.trim() !== '') {
-      this.filteredElements = this.filteredElements.filter((element) => {
-        return (element.name.toLowerCase().indexOf(val.toLowerCase()) > -1);
-      });
-
-      if (!this.filteredElements.includes(val.toLowerCase())) {
-        this.showAdd = true;
-        this.input = val;
-      }
-    }
-  }
-
-  elementSelected(element: Object, addNew: boolean = false) {
-    this.viewCtrl.dismiss(element, addNew);
+    modal.present();
   }
 }

--- a/src/providers/inventory-data.ts
+++ b/src/providers/inventory-data.ts
@@ -44,16 +44,32 @@ export class InventoryData {
     return Observable.fromPromise(Promise.resolve(TestData.brands));
   }
 
+  addBrand(brand: string) {
+    return Observable.fromPromise(Promise.resolve(TestData.brands[0]));
+  }
+
   getModels() {
     return Observable.fromPromise(Promise.resolve(TestData.models));
+  }
+
+  addModel(brand: string) {
+    return Observable.fromPromise(Promise.resolve(TestData.models[0]));
   }
 
   getStatuses() {
     return Observable.fromPromise(Promise.resolve(TestData.statuses));
   }
 
+  addStatus(brand: string) {
+    return Observable.fromPromise(Promise.resolve(TestData.statuses[0]));
+  }
+
   getCategories() {
     return Observable.fromPromise(Promise.resolve(TestData.categories));
+  }
+
+  addCategory(brand: string) {
+    return Observable.fromPromise(Promise.resolve(TestData.categories[0]));
   }
 
   private extractData(res: Response) {

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -45,6 +45,10 @@ export class TestData {
     { name: 'Sennheiser', id: 7}
   ];
 
+  public static filteredBrands = [
+    { name: 'Canon', id: 5 }
+  ];
+
   public static models = [
     { name: 'T5i', id: 5 },
     { name: 'e609', id: 6 },
@@ -68,6 +72,8 @@ export class TestData {
     email: 'luke@rebellion.com',
     password: 'yodarocks'
   };
+
+  public static queryText = 'Can';
 
   public static loginResponse = {
     id: 1,

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -1,10 +1,22 @@
 export class TestData {
-  public static item = {
+  public static apiItem = {
     tag: 'banana',
     brand: 'Canon',
+    brandID: 1,
     model: 'T5i',
+    modelID: 1,
     category: 'Camera',
-    status: 'Available'
+    categoryID: 1,
+    status: 'Available',
+    statusID: 1
+  };
+
+  public static item = {
+    tag: 'banana',
+    brandID: 1,
+    modelID: 1,
+    categoryID: 1,
+    statusID: 1
   };
 
   public static items = [{

--- a/src/test.ts
+++ b/src/test.ts
@@ -12,9 +12,9 @@ import 'zone.js/dist/fake-async-test';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, PopoverController } from 'ionic-angular';
+import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, ModalController,  } from 'ionic-angular';
 import { NgForm } from '@angular/forms';
-import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock, UserDataMock, PopoverMock } from './mocks';
+import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock, UserDataMock, ModalMock } from './mocks';
 import { InventoryData } from './providers/inventory-data';
 import { UserData } from './providers/user-data';
 
@@ -59,14 +59,14 @@ export class TestUtils {
       ],
       providers: [
         App, Form, Keyboard, DomController, MenuController, GestureController,
-        NgForm, PopoverController,
+        NgForm,
         { provide: Platform, useClass: PlatformMock },
         { provide: Config, useClass: ConfigMock },
         { provide: NavController, useClass: NavMock },
         { provide: NavParams, useClass: NavParamsMock },
         { provide: InventoryData, useClass: InventoryDataMock },
         { provide: UserData, useClass: UserDataMock },
-        { provide: PopoverController, useClass:PopoverMock }
+        { provide: ModalController, useClass: ModalMock }
       ],
       imports: [
         FormsModule,

--- a/src/test.ts
+++ b/src/test.ts
@@ -12,9 +12,9 @@ import 'zone.js/dist/fake-async-test';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams } from 'ionic-angular';
+import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, PopoverController } from 'ionic-angular';
 import { NgForm } from '@angular/forms';
-import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock, UserDataMock } from './mocks';
+import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock, UserDataMock, PopoverMock } from './mocks';
 import { InventoryData } from './providers/inventory-data';
 import { UserData } from './providers/user-data';
 
@@ -59,13 +59,14 @@ export class TestUtils {
       ],
       providers: [
         App, Form, Keyboard, DomController, MenuController, GestureController,
-        NgForm,
+        NgForm, PopoverController,
         { provide: Platform, useClass: PlatformMock },
         { provide: Config, useClass: ConfigMock },
         { provide: NavController, useClass: NavMock },
         { provide: NavParams, useClass: NavParamsMock },
         { provide: InventoryData, useClass: InventoryDataMock },
-        { provide: UserData, useClass: UserDataMock }
+        { provide: UserData, useClass: UserDataMock },
+        { provide: PopoverController, useClass:PopoverMock }
       ],
       imports: [
         FormsModule,

--- a/src/test.ts
+++ b/src/test.ts
@@ -12,7 +12,7 @@ import 'zone.js/dist/fake-async-test';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, ModalController,  } from 'ionic-angular';
+import { App, Config, Form, IonicModule, Keyboard, DomController, MenuController, NavController, Platform, GestureController, NavParams, ModalController } from 'ionic-angular';
 import { NgForm } from '@angular/forms';
 import { ConfigMock, PlatformMock, NavMock, NavParamsMock, InventoryDataMock, UserDataMock, ModalMock } from './mocks';
 import { InventoryData } from './providers/inventory-data';


### PR DESCRIPTION
Closes #77

This PR is kinda of a mess. This is a very important UI functionality to have, but it was hard to implement. In order to make it adapt to all item properties (brand, model, status and category), I had to make some ugly code (inside `presentModal()`). I could not think of another way to use the same modal for all properties.

As we talked about, adopting a different strategy for items and brands, models and categories might help implementing a cleaner solution on the front end.

Code coverage also dropped drastically because of the difficulty to mock and test modals.

I welcome any suggestion on how to improve this.