### PR TITLE
Fix date format for rentals

### DIFF
--- a/src/pages/rental-details/rental-details.spec.ts
+++ b/src/pages/rental-details/rental-details.spec.ts
@@ -66,6 +66,7 @@ describe('RentalDetails Page', () => {
   }));
 
   it('shows toast on error onRent()', fakeAsync(() => {
+    instance.details = TestData.details;
     instance.inventoryData.resolve = false;
     instance.items = TestData.items;
     spyOn(instance.stockpileData, 'showToast');

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -36,6 +36,10 @@ export class RentalDetailsPage {
     this.submitted = true;
 
     if (form.valid) {
+      // Transform date from ISO 8601 to MySQL date format
+      this.details.startDate = new Date(this.details.startDate).toISOString().substring(0, 10);
+      this.details.endDate = new Date(this.details.endDate).toISOString().substring(0, 10);
+
       let promises = [];
 
       for (const item of this.items) {


### PR DESCRIPTION
Closes #107 

Remove everything after the year, month and day in the date before making the call to the api to change the date to the format accepted by MySQL. Not the prettiest solution, but JavaScript's `Date` does not have any method to transform ISO 8601 dates to a format accepted by MySQL, so I had to do it by hand with `substring`.