### PR TITLE
Get status from item object

### DIFF
--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -108,14 +108,14 @@ describe('Home Page', () => {
     });
   }));
 
-  it('does not change page if segment is rent and status is rented', () => {
+  it('does not change page if segment is rent and item is not available', () => {
     instance.segment = Actions.rent;
     spyOn(instance.navCtrl, 'push');
     instance.pushPage(false);
     expect(instance.navCtrl.push).not.toHaveBeenCalled();
   });
 
-  it('does not change page if segment is return and status is available', () => {
+  it('does not change page if segment is return and item is available', () => {
     instance.segment = Actions.return;
     spyOn(instance.navCtrl, 'push');
     instance.pushPage(true);

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -44,11 +44,11 @@ describe('Home Page', () => {
 
   it('calls pushPage onNext()', fakeAsync(() => {
     instance.tag = TestData.item.tag;
-    instance.inventoryData.status = TestData.status;
+    instance.inventoryData.item = TestData.apiItem;
     spyOn(instance, 'pushPage');
     instance.onNext();
     tick();
-    expect(instance.pushPage).toHaveBeenCalledWith(TestData.status.status);
+    expect(instance.pushPage).toHaveBeenCalledWith(true);
   }));
 
   it('shows toast if error in onNext()', fakeAsync(() => {
@@ -67,7 +67,7 @@ describe('Home Page', () => {
     fixture.detectChanges();
     fixture.whenStable().then(() => {
       fixture.detectChanges();
-      instance.pushPage(Statuses.available);
+      instance.pushPage(true);
       expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { tag: TestData.item.tag, action: Actions.rent });
     });
   }));
@@ -79,7 +79,7 @@ describe('Home Page', () => {
     fixture.detectChanges();
     fixture.whenStable().then(() => {
       fixture.detectChanges();
-      instance.pushPage(Statuses.rented);
+      instance.pushPage(false);
       expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { tag: TestData.item.tag, action: Actions.return });
     });
   }));
@@ -111,14 +111,14 @@ describe('Home Page', () => {
   it('does not change page if segment is rent and status is rented', () => {
     instance.segment = Actions.rent;
     spyOn(instance.navCtrl, 'push');
-    instance.pushPage(Statuses.rented);
+    instance.pushPage(false);
     expect(instance.navCtrl.push).not.toHaveBeenCalled();
   });
 
   it('does not change page if segment is return and status is available', () => {
     instance.segment = Actions.return;
     spyOn(instance.navCtrl, 'push');
-    instance.pushPage(Statuses.available);
+    instance.pushPage(true);
     expect(instance.navCtrl.push).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -37,8 +37,8 @@ export class HomePage {
     }
   }
 
-  pushPage(status: boolean) {
-    if (this.segment === this.actions.rent && !status) {
+  pushPage(available: boolean) {
+    if (this.segment === this.actions.rent && !available) {
       let alert = this.alertCtrl.create({
         title: Messages.itemAlreadyRented,
         message: 'Do you want to return it instead?',
@@ -51,14 +51,14 @@ export class HomePage {
             text: 'Return Item',
             handler: () => {
               this.segment = this.actions.return;
-              this.pushPage(status);
+              this.pushPage(available);
             }
           }
         ]
       });
 
       alert.present();
-    } else if (this.segment === this.actions.return && status) {
+    } else if (this.segment === this.actions.return && available) {
       let alert = this.alertCtrl.create({
         title: Messages.itemNotRented,
         subTitle: 'Cannot return the item',

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -27,18 +27,18 @@ export class HomePage {
   onNext() {
     if (this.tag) {
       if (this.segment === this.actions.add) {
-        this.pushPage('');
+        this.pushPage(true);
       } else {
-        this.inventoryData.getStatus(this.tag).subscribe(
-          res => this.pushPage(res.status),
+        this.inventoryData.getItem(this.tag).subscribe(
+          item => this.pushPage(item.available === 1),
           err => this.stockpileData.showToast(err.message)
         );
       }
     }
   }
 
-  pushPage(status: string) {
-    if (this.segment === this.actions.rent && status.toLowerCase() === Statuses.rented.toLowerCase()) {
+  pushPage(status: boolean) {
+    if (this.segment === this.actions.rent && !status) {
       let alert = this.alertCtrl.create({
         title: Messages.itemAlreadyRented,
         message: 'Do you want to return it instead?',
@@ -58,7 +58,7 @@ export class HomePage {
       });
 
       alert.present();
-    } else if (this.segment === this.actions.return && status.toLowerCase() === Statuses.available.toLowerCase()) {
+    } else if (this.segment === this.actions.return && status) {
       let alert = this.alertCtrl.create({
         title: Messages.itemNotRented,
         subTitle: 'Cannot return the item',

--- a/src/providers/inventory-data.spec.ts
+++ b/src/providers/inventory-data.spec.ts
@@ -184,14 +184,4 @@ describe('InventoryData Provider', () => {
       expect(res).toEqual(TestData.response);
     });
   })));
-
-  it('returns a status on getStatus()', fakeAsync(inject([InventoryData, MockBackend], (inventoryData: InventoryData, mockBackend: MockBackend) => {
-    mockBackend.connections.subscribe(
-      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.status) })))
-    );
-    tick();
-    inventoryData.getStatus(TestData.item.tag).subscribe(res => {
-      expect(res).toEqual(TestData.status);
-    });
-  })));
 });

--- a/src/providers/inventory-data.ts
+++ b/src/providers/inventory-data.ts
@@ -81,10 +81,6 @@ export class InventoryData {
     return this.putEndpoint(Links.category, body);
   }
 
-  getStatus(tag: string) {
-    return this.getEndpoint(Links.item + '/' + tag + '/status');
-  }
-
   private getEndpoint(endpoint: string) {
     return this.authHttp.get(ApiUrl + endpoint)
       .map(this.extractData);

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -7,8 +7,7 @@ export class TestData {
     modelID: 1,
     category: 'Camera',
     categoryID: 1,
-    status: 'Available',
-    statusID: 1
+    available: 1
   };
 
   public static item = {
@@ -23,28 +22,28 @@ export class TestData {
     brandID: 1,
     modelID: 1,
     categoryID: 1,
-    status: 'Available'
+    available: 1
   },
   {
     tag: 'banana',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
-    status: 'Rented'
+    available: 0
   },
   {
     tag: 'mango',
     brandID: 3,
     modelID: 3,
     categoryID: 2,
-    status: 'Available'
+    available: 1
   },
   {
     tag: 'orange',
     brandID: 4,
     modelID: 4,
     categoryID: 2,
-    status: 'Rented'
+    available: 0
   }];
 
   public static details = {


### PR DESCRIPTION
Closes #115 

Replaced get status call by get item. Kept the original logic since it would be a bit complex to implement it for both rent/return and add/edit, but after add/edit get moved to the inventory view, I will be able to pass the whole item to the rent/return page which will prevent an identical call to get the item in each component.