### PR TITLE
134/Change API URL constant to a service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { RentalPage } from '../pages/rental/rental';
 import { RentalDetailsPage } from '../pages/rental-details/rental-details';
 import { TabsPage } from '../pages/tabs/tabs';
 
+import { ApiUrl } from '../providers/api-url';
 import { InventoryData } from '../providers/inventory-data';
 import { StockpileData } from '../providers/stockpile-data';
 import { UserData } from '../providers/user-data';
@@ -74,6 +75,7 @@ const cloudSettings: CloudSettings = {
   ],
   providers: [
     { provide: ErrorHandler, useClass: IonicErrorHandler },
+    ApiUrl,
     InventoryData,
     StockpileData,
     UserData,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,8 +5,6 @@ export class Actions {
   public static edit = 'Edit';
 };
 
-export const ApiUrl = '/api';
-
 export class Links {
   public static authenticate = '/auth';
   public static item = '/item';

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -7,6 +7,12 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/Rx';
 import { TestData } from './test-data';
 
+export class ApiUrlMock {
+  public getUrl(): string {
+    return '';
+  }
+}
+
 export class ConfigMock {
 
   public get(): any {
@@ -82,6 +88,18 @@ export class PlatformMock {
 
   public raf(callback: any): number {
     return 1;
+  }
+}
+
+export class PlatformMockIsCore {
+  public is(platform: string): Boolean {
+    return platform === 'core'
+  }
+}
+
+export class PlatformMockIsAndroid {
+  public is(platform: string): Boolean {
+    return platform === 'android'
   }
 }
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -62,6 +62,8 @@ export class NavMock {
 }
 
 export class PlatformMock {
+  currPlatform: string = 'core';
+
   public ready(): Promise<{String}> {
     return Promise.resolve('READY');
   }
@@ -89,17 +91,9 @@ export class PlatformMock {
   public raf(callback: any): number {
     return 1;
   }
-}
 
-export class PlatformMockIsCore {
   public is(platform: string): Boolean {
-    return platform === 'core'
-  }
-}
-
-export class PlatformMockIsAndroid {
-  public is(platform: string): Boolean {
-    return platform === 'android'
+    return platform === this.currPlatform;
   }
 }
 

--- a/src/providers/api-url.spec.ts
+++ b/src/providers/api-url.spec.ts
@@ -1,0 +1,24 @@
+import { ApiUrl } from './api-url';
+import { PlatformMock, PlatformMockIsCore, PlatformMockIsAndroid } from '../mocks';
+
+describe('ApiUrl Provider', () => {
+
+  let apiUrl: ApiUrl = null;
+
+  it('is created', () => {
+    apiUrl = new ApiUrl(<any> new PlatformMock);
+    expect(apiUrl).not.toBeNull();
+  });
+
+  it('returns remote URL when not on core platform', () => {
+    apiUrl = new ApiUrl(<any> new PlatformMockIsAndroid);
+    // URL starts with https:
+    expect(apiUrl.getUrl()).toMatch(/^https:/);
+  });
+
+  it('returns relative URL on core platform', () => {
+    apiUrl = new ApiUrl(<any> new PlatformMockIsCore);
+    // URL starts with forward slash
+    expect(apiUrl.getUrl()).toMatch(/^\//);
+  });
+});

--- a/src/providers/api-url.spec.ts
+++ b/src/providers/api-url.spec.ts
@@ -1,23 +1,26 @@
 import { ApiUrl } from './api-url';
-import { PlatformMock, PlatformMockIsCore, PlatformMockIsAndroid } from '../mocks';
+import { PlatformMock } from '../mocks';
 
 describe('ApiUrl Provider', () => {
 
   let apiUrl: ApiUrl = null;
 
-  it('is created', () => {
+  beforeEach(() => {
     apiUrl = new ApiUrl(<any> new PlatformMock);
+  });
+
+  it('is created', () => {
     expect(apiUrl).not.toBeNull();
   });
 
   it('returns remote URL when not on core platform', () => {
-    apiUrl = new ApiUrl(<any> new PlatformMockIsAndroid);
+    apiUrl.platform.currPlatform = 'android';
     // URL starts with https:
     expect(apiUrl.getUrl()).toMatch(/^https:/);
   });
 
   it('returns relative URL on core platform', () => {
-    apiUrl = new ApiUrl(<any> new PlatformMockIsCore);
+    apiUrl.platform.currPlatform = 'core';
     // URL starts with forward slash
     expect(apiUrl.getUrl()).toMatch(/^\//);
   });

--- a/src/providers/api-url.ts
+++ b/src/providers/api-url.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Platform } from 'ionic-angular';
+
+@Injectable()
+export class ApiUrl {
+  constructor(public platform: Platform) { }
+  getUrl() {
+    // Core platform is desktop web browser
+    if (this.platform.is('core')) {
+      return '/api';
+    } else {
+      return 'https://stockpile.adamvig.com/api';
+    }
+  }
+};

--- a/src/providers/inventory-data.spec.ts
+++ b/src/providers/inventory-data.spec.ts
@@ -3,16 +3,18 @@ import { BaseRequestOptions, Http, HttpModule, Response, ResponseOptions } from 
 import { MockBackend } from '@angular/http/testing';
 import { AuthHttp, AuthConfig } from 'angular2-jwt';
 
+import { ApiUrl } from './api-url';
 import { TestData } from '../test-data';
 import { InventoryData } from './inventory-data';
 import { StockpileData } from './stockpile-data';
-import { StockpileDataMock } from '../mocks';
+import { ApiUrlMock, StockpileDataMock } from '../mocks';
 
 describe('InventoryData Provider', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        { provide: ApiUrl, useClass: ApiUrlMock },
         InventoryData,
         { provide: StockpileData, useClass: StockpileDataMock },
         MockBackend,

--- a/src/providers/inventory-data.ts
+++ b/src/providers/inventory-data.ts
@@ -2,14 +2,19 @@ import { Injectable } from '@angular/core';
 import { Response, URLSearchParams } from '@angular/http';
 import { AuthHttp } from 'angular2-jwt';
 import { StockpileData } from './stockpile-data';
-import { Links, ApiUrl } from '../constants';
+import { Links } from '../constants';
+import { ApiUrl } from './api-url';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/Rx';
 
 @Injectable()
 export class InventoryData {
 
-  constructor(public authHttp: AuthHttp, public stockpileData: StockpileData) { }
+  constructor(
+    public apiUrl: ApiUrl,
+    public authHttp: AuthHttp,
+    public stockpileData: StockpileData
+  ) { }
 
   getItem(tag: string) {
     return this.getEndpoint(`${Links.item}/${tag}`);
@@ -101,19 +106,19 @@ export class InventoryData {
   }
 
   private getEndpoint(endpoint: string, params?: Object) {
-    return this.authHttp.get(`${ApiUrl}${endpoint}`, params)
+    return this.authHttp.get(`${this.apiUrl.getUrl()}${endpoint}`, params)
       .map(this.extractData)
       .catch(this.handleError);
   }
 
   private putEndpoint(endpoint: string, body: Object) {
-    return this.authHttp.put(`${ApiUrl}${endpoint}`, body)
+    return this.authHttp.put(`${this.apiUrl.getUrl()}${endpoint}`, body)
       .map(this.extractData)
       .catch(this.handleError);
   }
 
   private deleteEndpoint(endpoint: string) {
-    return this.authHttp.delete(`${ApiUrl}${endpoint}`)
+    return this.authHttp.delete(`${this.apiUrl.getUrl()}${endpoint}`)
       .map(this.extractData)
       .catch(this.handleError);
   }

--- a/src/providers/stockpile-data.spec.ts
+++ b/src/providers/stockpile-data.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { NavigatorMock, PlatformMock } from '../mocks';
+import { ApiUrlMock, NavigatorMock, PlatformMock } from '../mocks';
 
 import { StockpileData } from './stockpile-data';
 
@@ -8,7 +8,7 @@ let stockpileData: StockpileData = null;
 describe('StockpileData Provider', () => {
 
   beforeEach(() => {
-    stockpileData = new StockpileData(<any> new NavigatorMock, <any> new PlatformMock);
+    stockpileData = new StockpileData(<any> new ApiUrlMock, <any> new NavigatorMock, <any> new PlatformMock);
   });
 
   it('is created', () => {

--- a/src/providers/stockpile-data.ts
+++ b/src/providers/stockpile-data.ts
@@ -1,19 +1,23 @@
 import { Injectable } from '@angular/core';
 import { Platform } from 'ionic-angular';
 import { Navigator, HalDocument } from 'ng-hal';
-import { ApiUrl } from '../constants';
+import { ApiUrl } from './api-url';
 import { BarcodeScanner, Toast } from 'ionic-native';
 
 @Injectable()
 export class StockpileData {
   hal: HalDocument;
 
-  constructor(public navigator: Navigator, public platform: Platform) { }
+  constructor(
+    public apiUrl: ApiUrl,
+    public navigator: Navigator,
+    public platform: Platform
+  ) { }
 
   initHal() {
     return new Promise((resolve, reject) => {
       this.navigator
-        .get(ApiUrl)
+        .get(this.apiUrl.getUrl())
         .subscribe((doc: HalDocument) => {
           this.hal = doc;
           resolve();
@@ -25,7 +29,7 @@ export class StockpileData {
     // Ugly solution to extract endpoint from the HAL object.
     // The ng-hal library does not support this out of the box,
     // but they are planning on implementing it
-    return ApiUrl + this.hal.resource.allLinks()[key][0].href;
+    return this.apiUrl.getUrl() + this.hal.resource.allLinks()[key][0].href;
   }
 
   showToast(message: string) {

--- a/src/providers/user-data.spec.ts
+++ b/src/providers/user-data.spec.ts
@@ -4,16 +4,18 @@ import { MockBackend } from '@angular/http/testing';
 import { Storage } from '@ionic/storage';
 import { AuthHttp, AuthConfig } from 'angular2-jwt';
 
+import { ApiUrl } from './api-url';
 import { UserData } from './user-data';
 import { TestData } from '../test-data';
 import { StockpileData } from './stockpile-data';
-import { StockpileDataMock, StorageMock } from '../mocks';
+import { ApiUrlMock, StockpileDataMock, StorageMock } from '../mocks';
 
 describe('UserData Provider', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        { provide: ApiUrl, useClass: ApiUrlMock },
         UserData,
         { provide: Storage, useClass: StorageMock },
         { provide: StockpileData, useClass: StockpileDataMock },

--- a/src/providers/user-data.ts
+++ b/src/providers/user-data.ts
@@ -3,7 +3,8 @@ import { Response, Http } from '@angular/http';
 import { Storage } from '@ionic/storage';
 import { AuthHttp, tokenNotExpired } from 'angular2-jwt';
 import { StockpileData } from './stockpile-data';
-import { Links, ApiUrl } from '../constants';
+import { Links } from '../constants';
+import { ApiUrl } from './api-url'
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 
@@ -12,9 +13,10 @@ export class UserData {
   storage = new Storage();
 
   constructor(
+    public apiUrl: ApiUrl,
     public authHttp: AuthHttp,
     public stockpileData: StockpileData,
-    public http: Http
+    public http: Http,
   ) { }
 
   login(email: string, password: string) {
@@ -24,7 +26,7 @@ export class UserData {
     };
 
     return new Promise((resolve, reject) => {
-        this.http.post(`${ApiUrl}${Links.authenticate}`, creds)
+        this.http.post(`${this.apiUrl.getUrl()}${Links.authenticate}`, creds)
         .map(this.extractData)
         .catch((err, caught) => this.handleError(err, caught))
         .subscribe(


### PR DESCRIPTION
This enables the returned API URL to change depending on the platform it
is running on.

Closes #134.