### PR TITLE
Simplify typing barcodes

### DIFF
--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -3,7 +3,7 @@
     <button ion-button menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-    <ion-title>Scan</ion-title>
+    <ion-title>Rental</ion-title>
   </ion-navbar>
 </ion-header>
 
@@ -12,24 +12,10 @@
     <img src="assets/img/stockpile_tipi.svg" alt="Stockpile logo">
   </div>
 
-  <ion-segment [(ngModel)]="segment">
-    <ion-segment-button [value]="actions.rent">
-      {{actions.rent}}
-    </ion-segment-button>
-    <ion-segment-button [value]="actions.return">
-      {{actions.return}}
-    </ion-segment-button>
-  </ion-segment>
-
-	<ion-item>
-		<ion-input [(ngModel)]="tag" name="tag" type="text" placeholder="Tag">
-		</ion-input>
-	</ion-item>
-
-	<button ion-button class="tag-button" (click)="onNext()" type="submit" block [disabled]="!tag">
-    {{segment}}
+  <button ion-button (click)="onType()" block outline>
+    Type Barcode
   </button>
-  <button ion-button (click)="onScan()" block>
-    Scan
+  <button ion-button (click)="onScan()" block *ngIf="platform.is('cordova')">
+    Scan Barcode
   </button>
 </ion-content>

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -12,10 +12,10 @@
     <img src="assets/img/stockpile_tipi.svg" alt="Stockpile logo">
   </div>
 
-  <button ion-button (click)="onType()" block [outline]="platform.is('cordova')">
+  <button ion-button (click)="onTypeBarcode()" block [outline]="platform.is('cordova')">
     Type Barcode
   </button>
-  <button ion-button (click)="onScan()" block *ngIf="platform.is('cordova')">
+  <button ion-button (click)="onScanBarcode()" block *ngIf="platform.is('cordova')">
     Scan Barcode
   </button>
 </ion-content>

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -12,7 +12,7 @@
     <img src="assets/img/stockpile_tipi.svg" alt="Stockpile logo">
   </div>
 
-  <button ion-button (click)="onType()" block outline>
+  <button ion-button (click)="onType()" block [outline]="platform.is('cordova')">
     Type Barcode
   </button>
   <button ion-button (click)="onScan()" block *ngIf="platform.is('cordova')">

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -25,99 +25,47 @@ describe('Home Page', () => {
     expect(fixture).toBeTruthy();
   });
 
-  it('initializes with a segment of Rent', () => {
-    expect(instance.segment).toEqual('Rent');
-  });
-
-  it('calls onNext() on click', () => {
-    spyOn(instance, 'onNext');
-    TestUtils.eventFire(fixture.nativeElement.querySelectorAll('button[type="submit"]')[0], 'click');
-    expect(instance.onNext).toHaveBeenCalled();
-  });
-
-  it('calls onScan() on click', () => {
-    spyOn(instance, 'onScan');
-    TestUtils.eventFire(fixture.nativeElement.querySelectorAll('button')[4], 'click');
-    expect(instance.onScan).toHaveBeenCalled();
-  });
-
-  it('calls pushPage onNext()', fakeAsync(() => {
-    instance.tag = TestData.item.tag;
+  it('pushes rental page on pushPage() with \'Rent\' if item is avaiable', fakeAsync(() => {
     instance.inventoryData.item = TestData.apiItem;
-    spyOn(instance, 'pushPage');
-    instance.onNext();
+    spyOn(instance.navCtrl, 'push');
+    instance.pushPage(TestData.apiItem.tag);
     tick();
-    expect(instance.pushPage).toHaveBeenCalledWith(TestData.apiItem, true);
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { item: TestData.apiItem, action: Actions.rent });
   }));
 
-  it('shows toast if error in onNext()', fakeAsync(() => {
-    instance.tag = TestData.item.tag;
+  it('pushes rental page on pushPage() with \'Return\' if item is not available', fakeAsync(() => {
+    instance.inventoryData.item = TestData.rentedApiItem;
+    spyOn(instance.navCtrl, 'push');
+    instance.pushPage(TestData.rentedApiItem.tag);
+    tick();
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { item: TestData.rentedApiItem, action: Actions.return });
+  }));
+
+  it('shows toast if error in pushPage()', fakeAsync(() => {
     instance.inventoryData.resolve = false;
     spyOn(instance.notifications, 'showToast');
-    instance.onNext();
+    instance.pushPage(TestData.item.tag);
     tick();
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
 
-  it('pushes rental page on pushPage() with \'Rent\'', fakeAsync(() => {
-    instance.segment = Actions.rent;
-    instance.tag = TestData.item.tag;
-    instance.inventoryData.item = TestData.item;
-    spyOn(instance.navCtrl, 'push');
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      instance.pushPage(TestData.item, true);
-      expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { item: TestData.item, action: Actions.rent });
-    });
-  }));
-
-  it('pushes rental page on pushPage() with \'Return\'', fakeAsync(() => {
-    instance.segment = Actions.return;
-    instance.tag = TestData.item.tag;
-    instance.inventoryData.item = TestData.item;
-    spyOn(instance.navCtrl, 'push');
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      instance.pushPage(TestData.item, false);
-      expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { item: TestData.item, action: Actions.return });
-    });
-  }));
-
-  it('does not change page if segment is rent and item is not available', () => {
-    instance.segment = Actions.rent;
-    spyOn(instance.navCtrl, 'push');
-    instance.pushPage(TestData.item, false);
-    expect(instance.navCtrl.push).not.toHaveBeenCalled();
-  });
-
-  it('does not change page if segment is return and item is available', () => {
-    instance.segment = Actions.return;
-    spyOn(instance.navCtrl, 'push');
-    instance.pushPage(TestData.item, true);
-    expect(instance.navCtrl.push).not.toHaveBeenCalled();
-  });
-
   it('calls barcodeScanner.scan() onScan()', fakeAsync(() => {
     spyOn(instance.barcodeScanner, 'scan').and.callThrough();
-    spyOn(instance, 'onNext');
+    spyOn(instance, 'pushPage');
     instance.onScan();
     tick();
     expect(instance.barcodeScanner.scan).toHaveBeenCalled();
-    expect(instance.onNext).toHaveBeenCalled();
-    expect(instance.tag).toEqual(TestData.barcodeData.text);
+    expect(instance.pushPage).toHaveBeenCalledWith(TestData.barcodeData.text);
   }));
 
   it('does nothing if scan is cancelled', fakeAsync(() => {
     instance.barcodeScanner.cancel = true;
     spyOn(instance.notifications, 'showToast');
-    spyOn(instance, 'onNext');
+    spyOn(instance, 'pushPage');
     instance.onScan();
     tick();
-    expect(instance.onNext).not.toHaveBeenCalled();
+    expect(instance.pushPage).not.toHaveBeenCalled();
     expect(instance.notifications.showToast).not.toHaveBeenCalled();
-    expect(instance.tag).toEqual('');
   }));
 
   it('shows toast if error in onScan()', fakeAsync(() => {
@@ -127,4 +75,10 @@ describe('Home Page', () => {
     tick();
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
+
+  it('creates an alert onType()', () => {
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onType();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
 });

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -28,7 +28,7 @@ describe('Home Page', () => {
   it('pushes rental page on pushPage() with \'Rent\' if item is avaiable', fakeAsync(() => {
     instance.inventoryData.item = TestData.apiItem;
     spyOn(instance.navCtrl, 'push');
-    instance.pushPage(TestData.apiItem.tag);
+    instance.pushPage(TestData.apiItem.barcode);
     tick();
     expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { item: TestData.apiItem, action: Actions.rent });
   }));
@@ -36,7 +36,7 @@ describe('Home Page', () => {
   it('pushes rental page on pushPage() with \'Return\' if item is not available', fakeAsync(() => {
     instance.inventoryData.item = TestData.rentedApiItem;
     spyOn(instance.navCtrl, 'push');
-    instance.pushPage(TestData.rentedApiItem.tag);
+    instance.pushPage(TestData.rentedApiItem.barcode);
     tick();
     expect(instance.navCtrl.push).toHaveBeenCalledWith(RentalPage, { item: TestData.rentedApiItem, action: Actions.return });
   }));
@@ -44,7 +44,7 @@ describe('Home Page', () => {
   it('shows toast if error in pushPage()', fakeAsync(() => {
     instance.inventoryData.resolve = false;
     spyOn(instance.notifications, 'showToast');
-    instance.pushPage(TestData.item.tag);
+    instance.pushPage(TestData.item.barcode);
     tick();
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -49,10 +49,10 @@ describe('Home Page', () => {
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
 
-  it('calls barcodeScanner.scan() onScan()', fakeAsync(() => {
+  it('calls barcodeScanner.scan() onScanBarcode()', fakeAsync(() => {
     spyOn(instance.barcodeScanner, 'scan').and.callThrough();
     spyOn(instance, 'pushPage');
-    instance.onScan();
+    instance.onScanBarcode();
     tick();
     expect(instance.barcodeScanner.scan).toHaveBeenCalled();
     expect(instance.pushPage).toHaveBeenCalledWith(TestData.barcodeData.text);
@@ -62,23 +62,23 @@ describe('Home Page', () => {
     instance.barcodeScanner.cancel = true;
     spyOn(instance.notifications, 'showToast');
     spyOn(instance, 'pushPage');
-    instance.onScan();
+    instance.onScanBarcode();
     tick();
     expect(instance.pushPage).not.toHaveBeenCalled();
     expect(instance.notifications.showToast).not.toHaveBeenCalled();
   }));
 
-  it('shows toast if error in onScan()', fakeAsync(() => {
+  it('shows toast if error in onScanBarcode()', fakeAsync(() => {
     instance.barcodeScanner.resolve = false;
     spyOn(instance.notifications, 'showToast');
-    instance.onScan();
+    instance.onScanBarcode();
     tick();
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
 
-  it('creates an alert onType()', () => {
+  it('creates an alert onTypeBarcode()', () => {
     spyOn(instance.alertCtrl, 'create').and.callThrough();
-    instance.onType();
+    instance.onTypeBarcode();
     expect(instance.alertCtrl.create).toHaveBeenCalled();
   });
 });

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -3,7 +3,7 @@ import { NavController, AlertController, Platform } from 'ionic-angular';
 import { BarcodeScanner } from '@ionic-native/barcode-scanner';
 
 import { RentalPage } from '../rental/rental';
-import { Actions, Messages } from '../../constants';
+import { Actions } from '../../constants';
 import { Notifications } from '../../providers/notifications';
 import { InventoryData } from '../../providers/inventory-data';
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -22,8 +22,8 @@ export class HomePage {
     public platform: Platform
   ) { }
 
-  pushPage(tag: string) {
-    this.inventoryData.getItem(tag).subscribe(
+  pushPage(barcode: string) {
+    this.inventoryData.getItem(barcode).subscribe(
       (item: any) => {
         let action;
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -44,7 +44,7 @@ export class HomePage {
     );
   }
 
-  onScan() {
+  onScanBarcode() {
     this.barcodeScanner.scan().then(
       barcodeData => {
         if (!barcodeData.cancelled) {
@@ -55,7 +55,7 @@ export class HomePage {
     );
   }
 
-  onType() {
+  onTypeBarcode() {
     let alert = this.alertCtrl.create({
       title: 'Type Barcode',
       inputs: [

--- a/src/pages/inventory/inventory.spec.ts
+++ b/src/pages/inventory/inventory.spec.ts
@@ -80,7 +80,7 @@ describe('Inventory Page', () => {
   it('pushes ItemPage on nav on viewItem()', () => {
     spyOn(instance.navCtrl, 'push');
     instance.viewItem(TestData.item);
-    expect(instance.navCtrl.push).toHaveBeenCalledWith(ItemPage, { tag: TestData.item.tag, action: Actions.edit });
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(ItemPage, { barcode: TestData.item.barcode, action: Actions.edit });
   });
 
   it('filters models on filterModels()', () => {
@@ -96,7 +96,7 @@ describe('Inventory Page', () => {
     instance.onAdd();
     tick();
     expect(instance.barcodeScanner.scan).toHaveBeenCalled();
-    expect(instance.navCtrl.push).toHaveBeenCalledWith(ItemPage, { tag: TestData.barcodeData.text, action: Actions.add });
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(ItemPage, { barcode: TestData.barcodeData.text, action: Actions.add });
   }));
 
   it('shows toast if error in onAdd()', fakeAsync(() => {

--- a/src/pages/inventory/inventory.ts
+++ b/src/pages/inventory/inventory.ts
@@ -83,7 +83,7 @@ export class InventoryPage {
 
   viewItem(item) {
     this.navCtrl.push(ItemPage, {
-      tag: item.tag,
+      barcode: item.barcode,
       action: Actions.edit
     });
   }
@@ -93,7 +93,7 @@ export class InventoryPage {
       barcodeData => {
         if (!barcodeData.cancelled) {
           this.navCtrl.push(ItemPage, {
-            tag: barcodeData.text,
+            barcode: barcodeData.text,
             action: Actions.add
           });
         }

--- a/src/pages/item/item.spec.ts
+++ b/src/pages/item/item.spec.ts
@@ -26,10 +26,10 @@ describe('Item Page', () => {
     expect(fixture).toBeTruthy();
   });
 
-  it('gets navParam tag', () => {
-    instance.navParams.param = TestData.item.tag;
+  it('gets navParam barcode', () => {
+    instance.navParams.param = TestData.item.barcode;
     instance.ngOnInit();
-    expect(instance.item.tag).toEqual(TestData.item.tag);
+    expect(instance.item.barcode).toEqual(TestData.item.barcode);
   });
 
   it('gets navParam action', () => {
@@ -93,7 +93,7 @@ describe('Item Page', () => {
       tick();
       expect(instance.navCtrl.pop).toHaveBeenCalled();
       expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.itemAdded);
-      expect(instance.events.publish).toHaveBeenCalledWith('item:edited', instance.inventoryData.item.tag);
+      expect(instance.events.publish).toHaveBeenCalledWith('item:edited', instance.inventoryData.item.barcode);
     });
   }));
 
@@ -112,7 +112,7 @@ describe('Item Page', () => {
       tick();
       expect(instance.navCtrl.pop).toHaveBeenCalled();
       expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.itemEdited);
-      expect(instance.events.publish).toHaveBeenCalledWith('item:edited', instance.inventoryData.item.tag);
+      expect(instance.events.publish).toHaveBeenCalledWith('item:edited', instance.inventoryData.item.barcode);
     });
   }));
 

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -16,7 +16,7 @@ export class ItemPage {
   actions = Actions;
   itemProperties = ItemProperties;
   action: Actions = '';
-  item: {modelID?: number, categoryID?: number, tag?: string} = {};
+  item: {modelID?: number, categoryID?: number, barcode?: string} = {};
   selectedBrandID: number;
   selectedBrand: string;
   allBrands;
@@ -36,7 +36,7 @@ export class ItemPage {
   ) { }
 
   ngOnInit() {
-    this.item.tag = this.navParams.get('tag');
+    this.item.barcode = this.navParams.get('barcode');
     this.action = this.navParams.get('action');
 
     this.inventoryData.getBrands().subscribe(
@@ -50,11 +50,11 @@ export class ItemPage {
     );
 
     if (this.action === this.actions.edit) {
-      this.inventoryData.getItem(this.item.tag).subscribe(
+      this.inventoryData.getItem(this.item.barcode).subscribe(
         (item: any) => {
           this.item.modelID = item.modelID;
           this.item.categoryID = item.categoryID;
-          this.item.tag = item.tag;
+          this.item.barcode = item.barcode;
           this.selectedBrandID = item.brandID;
           this.selectedBrand = item.brand;
           this.selectedModel = item.model;
@@ -88,14 +88,14 @@ export class ItemPage {
         apiCall = this.inventoryData.addItem(this.item);
         message = Messages.itemAdded;
       } else if (this.action === this.actions.edit) {
-        apiCall = this.inventoryData.editItem(this.item, this.item.tag);
+        apiCall = this.inventoryData.editItem(this.item, this.item.barcode);
         message = Messages.itemEdited;
       }
 
       apiCall.subscribe(
         item => {
           this.notifications.showToast(message);
-          this.events.publish('item:edited', item.tag);
+          this.events.publish('item:edited', item.barcode);
           this.navCtrl.pop();
         },
         err => this.notifications.showToast(err)
@@ -104,7 +104,7 @@ export class ItemPage {
   }
 
   onDelete() {
-    this.inventoryData.deleteItem(this.item.tag).subscribe(
+    this.inventoryData.deleteItem(this.item.barcode).subscribe(
       success => {
         this.notifications.showToast(Messages.itemDeleted);
         this.navCtrl.pop();

--- a/src/pages/rental/rental.html
+++ b/src/pages/rental/rental.html
@@ -6,18 +6,6 @@
 
 <ion-content padding>
 
-	<ion-item>
-		<ion-input [(ngModel)]="tag" name="tag" type="text" placeholder="Tag">
-		</ion-input>
-	</ion-item>
-
-	<button ion-button class="tag-button" (click)="onAdd()" type="submit" block [disabled]="!tag">
-    Add
-  </button>
-  <button ion-button (click)="onScan()" block>
-    Scan
-  </button>
-
   <ion-list-header>Scanned Items</ion-list-header>
 
   <ion-list>
@@ -29,6 +17,12 @@
     </ion-item>
   </ion-list>
 
+  <button ion-button (click)="onType()" block outline>
+    Add More Items
+  </button>
+  <button ion-button (click)="onScan()" block outline *ngIf="platform.is('cordova')">
+    Scan More Items
+  </button>
   <button ion-button *ngIf="action === actions.rent" (click)="onContinue()" block>
     Continue
   </button>

--- a/src/pages/rental/rental.html
+++ b/src/pages/rental/rental.html
@@ -17,10 +17,10 @@
     </ion-item>
   </ion-list>
 
-  <button ion-button (click)="onType()" block outline>
+  <button ion-button (click)="onTypeBarcode()" block outline>
     Add More Items
   </button>
-  <button ion-button (click)="onScan()" block outline *ngIf="platform.is('cordova')">
+  <button ion-button (click)="onScanBarcode()" block outline *ngIf="platform.is('cordova')">
     Scan More Items
   </button>
   <button ion-button *ngIf="action === actions.rent" (click)="onContinue()" block>

--- a/src/pages/rental/rental.html
+++ b/src/pages/rental/rental.html
@@ -11,7 +11,7 @@
   <ion-list>
     <ion-item *ngFor="let item of items" (click)="viewItem(item)">
       <h2>{{ item.brand }} {{ item.model }}</h2>
-      <button ion-button clear item-right color="dark" (click)="onRemoveItem(item.tag)">
+      <button ion-button clear item-right color="dark" (click)="onRemoveItem(item.barcode)">
         <ion-icon name="close"></ion-icon>
       </button>
     </ion-item>

--- a/src/pages/rental/rental.spec.ts
+++ b/src/pages/rental/rental.spec.ts
@@ -41,7 +41,7 @@ describe('Rental Page', () => {
     instance.inventoryData.item = TestData.modifiedItem;
     instance.ngOnInit();
     instance.items = TestData.items;
-    instance.events.publish('item:edited', TestData.modifiedItem.tag);
+    instance.events.publish('item:edited', TestData.modifiedItem.barcode);
     tick();
     expect(instance.items).toEqual(TestData.modifiedItems);
   }));
@@ -51,14 +51,14 @@ describe('Rental Page', () => {
     instance.ngOnInit();
     instance.items = TestData.items;
     spyOn(instance.notifications, 'showToast');
-    instance.events.publish('item:edited', TestData.modifiedItem.tag);
+    instance.events.publish('item:edited', TestData.modifiedItem.barcode);
     tick();
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
 
   it('pushes item onAdd()', fakeAsync(() => {
     instance.inventoryData.item = TestData.apiItem;
-    instance.onAdd(TestData.apiItem.tag);
+    instance.onAdd(TestData.apiItem.barcode);
     tick();
     expect(instance.items).toEqual([TestData.apiItem]);
   }));
@@ -101,7 +101,7 @@ describe('Rental Page', () => {
   it('pushes ItemPage on nav on viewItem()', () => {
     spyOn(instance.navCtrl, 'push');
     instance.viewItem(TestData.item);
-    expect(instance.navCtrl.push).toHaveBeenCalledWith(ItemPage, { tag: TestData.item.tag, action: Actions.edit });
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(ItemPage, { barcode: TestData.item.barcode, action: Actions.edit });
   });
 
   it('pushes RentalDetailsPage on nav onContinue()', () => {
@@ -136,7 +136,7 @@ describe('Rental Page', () => {
     instance.onReturn();
     tick();
     expect(instance.navCtrl.pop).toHaveBeenCalled();
-    expect(instance.inventoryData.return).toHaveBeenCalledWith(TestData.item.tag);
+    expect(instance.inventoryData.return).toHaveBeenCalledWith(TestData.item.barcode);
   }));
 
   it('calls barcodeScanner.scan() onScanBarcode()', fakeAsync(() => {
@@ -174,7 +174,7 @@ describe('Rental Page', () => {
 
   it('removes item from the list onRemoveItem()', () => {
     instance.items = TestData.items;
-    instance.onRemoveItem(TestData.tag);
+    instance.onRemoveItem(TestData.barcode);
     expect(instance.items).toEqual(TestData.itemsMinusOne);
   });
 });

--- a/src/pages/rental/rental.spec.ts
+++ b/src/pages/rental/rental.spec.ts
@@ -139,19 +139,19 @@ describe('Rental Page', () => {
     expect(instance.inventoryData.return).toHaveBeenCalledWith(TestData.item.tag);
   }));
 
-  it('calls barcodeScanner.scan() onScan()', fakeAsync(() => {
+  it('calls barcodeScanner.scan() onScanBarcode()', fakeAsync(() => {
     spyOn(instance.barcodeScanner, 'scan').and.callThrough();
     spyOn(instance, 'onAdd');
-    instance.onScan();
+    instance.onScanBarcode();
     tick();
     expect(instance.barcodeScanner.scan).toHaveBeenCalled();
     expect(instance.onAdd).toHaveBeenCalledWith(TestData.barcodeData.text);
   }));
 
-  it('shows toast if error in onScan()', fakeAsync(() => {
+  it('shows toast if error in onScanBarcode()', fakeAsync(() => {
     instance.barcodeScanner.resolve = false;
     spyOn(instance.notifications, 'showToast');
-    instance.onScan();
+    instance.onScanBarcode();
     tick();
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
@@ -160,15 +160,15 @@ describe('Rental Page', () => {
     instance.barcodeScanner.cancel = true;
     spyOn(instance.notifications, 'showToast');
     spyOn(instance, 'onAdd');
-    instance.onScan();
+    instance.onScanBarcode();
     tick();
     expect(instance.onAdd).not.toHaveBeenCalled();
     expect(instance.notifications.showToast).not.toHaveBeenCalled();
   }));
 
-  it('creates an alert onType()', () => {
+  it('creates an alert onTypeBarcode()', () => {
     spyOn(instance.alertCtrl, 'create').and.callThrough();
-    instance.onType();
+    instance.onTypeBarcode();
     expect(instance.alertCtrl.create).toHaveBeenCalled();
   });
 

--- a/src/pages/rental/rental.spec.ts
+++ b/src/pages/rental/rental.spec.ts
@@ -56,31 +56,9 @@ describe('Rental Page', () => {
     expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
   }));
 
-  it('calls onAdd() on click on add button', () => {
-    spyOn(instance, 'onAdd');
-    TestUtils.eventFire(fixture.nativeElement.querySelectorAll('button[type="submit"]')[0], 'click');
-    expect(instance.onAdd).toHaveBeenCalled();
-  });
-
-  it('calls onScan() on click on add button', () => {
-    spyOn(instance, 'onScan');
-    TestUtils.eventFire(fixture.nativeElement.querySelectorAll('button')[3], 'click');
-    expect(instance.onScan).toHaveBeenCalled();
-  });
-
-  it('calls viewItem() on click on an item', fakeAsync(() => {
-    instance.navParams.param = TestData.item;
-    spyOn(instance, 'viewItem');
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      TestUtils.eventFire(fixture.nativeElement.querySelectorAll('button')[4], 'click');
-      expect(instance.viewItem).toHaveBeenCalledWith(TestData.item);
-    });
-  }));
-
   it('pushes item onAdd()', fakeAsync(() => {
-    instance.onAdd();
+    instance.inventoryData.item = TestData.apiItem;
+    instance.onAdd(TestData.apiItem.tag);
     tick();
     expect(instance.items).toEqual([TestData.apiItem]);
   }));
@@ -167,8 +145,7 @@ describe('Rental Page', () => {
     instance.onScan();
     tick();
     expect(instance.barcodeScanner.scan).toHaveBeenCalled();
-    expect(instance.onAdd).toHaveBeenCalled();
-    expect(instance.tag).toEqual(TestData.barcodeData.text);
+    expect(instance.onAdd).toHaveBeenCalledWith(TestData.barcodeData.text);
   }));
 
   it('shows toast if error in onScan()', fakeAsync(() => {
@@ -187,8 +164,13 @@ describe('Rental Page', () => {
     tick();
     expect(instance.onAdd).not.toHaveBeenCalled();
     expect(instance.notifications.showToast).not.toHaveBeenCalled();
-    expect(instance.tag).toEqual('');
   }));
+
+  it('creates an alert onType()', () => {
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onType();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
 
   it('removes item from the list onRemoveItem()', () => {
     instance.items = TestData.items;

--- a/src/pages/rental/rental.ts
+++ b/src/pages/rental/rental.ts
@@ -33,24 +33,24 @@ export class RentalPage {
     const item = this.navParams.get('item');
     this.items.push(item);
 
-    this.events.subscribe('item:edited', tag => {
-      const index = this.items.findIndex(item => item.tag === tag);
+    this.events.subscribe('item:edited', barcode => {
+      const index = this.items.findIndex(item => item.barcode === barcode);
 
-      this.inventoryData.getItem(tag).subscribe(
+      this.inventoryData.getItem(barcode).subscribe(
         item => this.items.splice(index, 1, item),
         err => this.notifications.showToast(err)
       );
     });
   }
 
-  onAdd(tag: string) {
-    this.inventoryData.getItem(tag).subscribe(
+  onAdd(barcode: string) {
+    this.inventoryData.getItem(barcode).subscribe(
       item => {
         if (item.available === 0 && this.action === Actions.rent) {
           this.notifications.showToast(Messages.itemAlreadyRented);
         } else if (item.available === 1 && this.action === Actions.return) {
           this.notifications.showToast(Messages.itemNotRented);
-        } else if (this.items.some(listItem => listItem.tag === item.tag)) {
+        } else if (this.items.some(listItem => listItem.barcode === item.barcode)) {
           this.notifications.showToast(Messages.itemAlreadyAdded);
         } else {
           this.items.push(item);
@@ -62,7 +62,7 @@ export class RentalPage {
 
   viewItem(item) {
     this.navCtrl.push(ItemPage, {
-      tag: item.tag,
+      barcode: item.barcode,
       action: Actions.edit
     });
   }
@@ -77,7 +77,7 @@ export class RentalPage {
     let returns = [];
 
     for (const item of this.items) {
-      returns.push(this.inventoryData.return(item.tag).toPromise());
+      returns.push(this.inventoryData.return(item.barcode).toPromise());
     }
 
     Promise.all(returns).then(
@@ -126,8 +126,8 @@ export class RentalPage {
     alert.present();
   }
 
-  onRemoveItem(tag) {
-    const index = this.items.findIndex(item => item.tag === tag);
+  onRemoveItem(barcode) {
+    const index = this.items.findIndex(item => item.barcode === barcode);
 
     this.items.splice(index, 1);
   }

--- a/src/pages/rental/rental.ts
+++ b/src/pages/rental/rental.ts
@@ -89,7 +89,7 @@ export class RentalPage {
     );
   }
 
-  onScan() {
+  onScanBarcode() {
     this.barcodeScanner.scan().then(
       barcodeData => {
         if (!barcodeData.cancelled) {
@@ -100,7 +100,7 @@ export class RentalPage {
     );
   }
 
-  onType() {
+  onTypeBarcode() {
     let alert = this.alertCtrl.create({
       title: 'Type Barcode',
       inputs: [

--- a/src/pages/tabs/tabs.html
+++ b/src/pages/tabs/tabs.html
@@ -1,4 +1,4 @@
 <ion-tabs>
-  <ion-tab [root]="tab1Root" tabTitle="Scan" tabIcon="qr-scanner"></ion-tab>
+  <ion-tab [root]="tab1Root" tabTitle="Rental" tabIcon="qr-scanner"></ion-tab>
   <ion-tab [root]="tab2Root" tabTitle="Inventory" tabIcon="cube"></ion-tab>
 </ion-tabs>

--- a/src/providers/inventory-data.spec.ts
+++ b/src/providers/inventory-data.spec.ts
@@ -49,7 +49,7 @@ describe('InventoryData Provider', () => {
       conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.item) })))
     );
     tick();
-    inventoryData.getItem(TestData.item.tag).subscribe(
+    inventoryData.getItem(TestData.item.barcode).subscribe(
       item => expect(item).toEqual(TestData.item),
       err => fail(err)
     );
@@ -82,7 +82,7 @@ describe('InventoryData Provider', () => {
       conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
     );
     tick();
-    inventoryData.editItem(TestData.item, TestData.item.tag).subscribe(
+    inventoryData.editItem(TestData.item, TestData.item.barcode).subscribe(
       res => expect(res).toEqual(TestData.response),
       err => fail(err)
     );
@@ -93,7 +93,7 @@ describe('InventoryData Provider', () => {
       conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
     );
     tick();
-    inventoryData.deleteItem(TestData.item.tag).subscribe(
+    inventoryData.deleteItem(TestData.item.barcode).subscribe(
       res => expect(res).toEqual(TestData.response),
       err => fail(err)
     );
@@ -126,7 +126,7 @@ describe('InventoryData Provider', () => {
       conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
     );
     tick();
-    inventoryData.return(TestData.item.tag).subscribe(
+    inventoryData.return(TestData.item.barcode).subscribe(
       res => expect(res).toEqual(TestData.response),
       err => fail(err)
     );
@@ -225,7 +225,7 @@ describe('InventoryData Provider', () => {
       conn => conn.mockError(new Response(new ResponseOptions({ body: { message: TestData.error } })))
     );
     tick();
-    inventoryData.deleteItem(TestData.item.tag).subscribe(
+    inventoryData.deleteItem(TestData.item.barcode).subscribe(
       res => fail('Did not return an error'),
       err => expect(err).toEqual(TestData.error)
     );

--- a/src/providers/inventory-data.ts
+++ b/src/providers/inventory-data.ts
@@ -14,8 +14,8 @@ export class InventoryData {
     public authHttp: AuthHttp
   ) { }
 
-  getItem(tag: string) {
-    return this.getEndpoint(`${Links.item}/${tag}`);
+  getItem(barcode: string) {
+    return this.getEndpoint(`${Links.item}/${barcode}`);
   }
 
   getAllItems() {
@@ -26,12 +26,12 @@ export class InventoryData {
     return this.putEndpoint(Links.item, item);
   }
 
-  editItem(item: Object, tag: string) {
-    return this.putEndpoint(`${Links.item}/${tag}`, item);
+  editItem(item: Object, barcode: string) {
+    return this.putEndpoint(`${Links.item}/${barcode}`, item);
   }
 
-  deleteItem(tag: string) {
-    return this.deleteEndpoint(`${Links.item}/${tag}`);
+  deleteItem(barcode: string) {
+    return this.deleteEndpoint(`${Links.item}/${barcode}`);
   }
 
   filterItems(brandID?: number, modelID?: number, categoryID?: number, available?: number) {
@@ -62,8 +62,8 @@ export class InventoryData {
     return this.putEndpoint(Links.rental, rental);
   }
 
-  return(tag: string) {
-      return this.deleteEndpoint(`${Links.rental}/${tag}`);
+  return(barcode: string) {
+      return this.deleteEndpoint(`${Links.rental}/${barcode}`);
   }
 
   getBrands() {

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -1,6 +1,6 @@
 export class TestData {
   public static apiItem = {
-    tag: 'banana',
+    barcode: 'banana',
     brand: 'Canon',
     brandID: 1,
     model: 'T5i',
@@ -11,7 +11,7 @@ export class TestData {
   };
 
   public static rentedApiItem = {
-    tag: 'banana',
+    barcode: 'banana',
     brand: 'Canon',
     brandID: 1,
     model: 'T5i',
@@ -22,13 +22,13 @@ export class TestData {
   };
 
   public static item = {
-    tag: 'banana',
+    barcode: 'banana',
     modelID: 1,
     categoryID: 1
   };
 
   public static modifiedItem = {
-    tag: 'mango',
+    barcode: 'mango',
     brandID: 2,
     modelID: 3,
     categoryID: 3,
@@ -36,28 +36,28 @@ export class TestData {
   };
 
   public static modifiedItems = [{
-    tag: 'apple',
+    barcode: 'apple',
     brandID: 1,
     modelID: 1,
     categoryID: 1,
     available: 1
   },
   {
-    tag: 'banana',
+    barcode: 'banana',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
     available: 0
   },
   {
-    tag: 'mango',
+    barcode: 'mango',
     brandID: 2,
     modelID: 3,
     categoryID: 3,
     available: 1
   },
   {
-    tag: 'orange',
+    barcode: 'orange',
     brandID: 4,
     modelID: 4,
     categoryID: 2,
@@ -65,52 +65,52 @@ export class TestData {
   }];
 
   public static items = [{
-    tag: 'apple',
+    barcode: 'apple',
     brandID: 1,
     modelID: 1,
     categoryID: 1,
     available: 1
   },
   {
-    tag: 'banana',
+    barcode: 'banana',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
     available: 0
   },
   {
-    tag: 'mango',
+    barcode: 'mango',
     brandID: 3,
     modelID: 3,
     categoryID: 2,
     available: 1
   },
   {
-    tag: 'orange',
+    barcode: 'orange',
     brandID: 4,
     modelID: 4,
     categoryID: 2,
     available: 0
   }];
 
-  public static tag = 'mango';
+  public static barcode = 'mango';
 
   public static itemsMinusOne = [{
-    tag: 'apple',
+    barcode: 'apple',
     brandID: 1,
     modelID: 1,
     categoryID: 1,
     available: 1
   },
   {
-    tag: 'banana',
+    barcode: 'banana',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
     available: 0
   },
   {
-    tag: 'orange',
+    barcode: 'orange',
     brandID: 4,
     modelID: 4,
     categoryID: 2,
@@ -119,14 +119,14 @@ export class TestData {
 
   public static filteredItems = {
     results: [{
-      tag: 'apple',
+      barcode: 'apple',
       brandID: 1,
       modelID: 1,
       categoryID: 1,
       available: 1
     },
     {
-      tag: 'banana',
+      barcode: 'banana',
       brandID: 2,
       modelID: 2,
       categoryID: 1,


### PR DESCRIPTION
Closes #197, closes #186 and closes #161 

I also renamed the scan tab to "Rental". Not the greatest name, but without it, there is no indication of why you would want to scan items.

The scan button is also not shown on desktop anymore. It didn't make sense to show a feature that is not available. Typing barcodes is still available everywhere, but we'd have to check if it is necessary to keep it or not (if our client ever think to type barcodes instead of scanning them).

Here are a few screenshots of what it looks like:
<img width="742" alt="screen shot 2017-03-31 at 2 40 09 pm" src="https://cloud.githubusercontent.com/assets/12487270/24564497/20afdd60-1620-11e7-9e08-48de16dfea82.png">
<img width="737" alt="screen shot 2017-03-31 at 2 40 18 pm" src="https://cloud.githubusercontent.com/assets/12487270/24564496/20af4dc8-1620-11e7-96cd-88965c6aafb4.png">
<img width="743" alt="screen shot 2017-03-31 at 2 40 55 pm" src="https://cloud.githubusercontent.com/assets/12487270/24564498/20b34180-1620-11e7-9c23-80fe2082161c.png">
