### PR TITLE
Improve adding new brands, models, categories

### DIFF
--- a/src/pages/item-filter/item-filter.html
+++ b/src/pages/item-filter/item-filter.html
@@ -18,11 +18,15 @@
 </ion-header>
 <ion-content>
   <ion-list>
-    <button ion-item detail-none *ngFor="let element of filteredElements" (click)="dismiss(element)">
-      {{ element.name }}
+    <button ion-item detail-none *ngIf="!showNew" (click)="onCreate()">
+       Create new {{ type.toLowerCase() }}
+       <ion-icon name="add" item-right></ion-icon>
     </button>
     <button ion-item detail-none *ngIf="showNew" (click)="dismiss(queryText, true)">
        Create new {{ type.toLowerCase() }}: {{ queryText }}
+    </button>
+    <button ion-item detail-none *ngFor="let element of filteredElements" (click)="dismiss(element)">
+      {{ element.name }}
     </button>
   </ion-list>
 </ion-content>

--- a/src/pages/item-filter/item-filter.spec.ts
+++ b/src/pages/item-filter/item-filter.spec.ts
@@ -1,6 +1,6 @@
 import { TestData } from '../../test-data';
 import { ViewController } from 'ionic-angular';
-import { NavParamsMock } from '../../mocks';
+import { NavParamsMock, AlertMock } from '../../mocks';
 
 import { ItemFilterPage } from './item-filter';
 import { ItemProperties } from '../../constants';
@@ -10,7 +10,11 @@ let itemFilterPage: ItemFilterPage = null;
 describe('ItemFilter Page', () => {
 
   beforeEach(() => {
-    itemFilterPage = new ItemFilterPage(<any> new ViewController, <any> new NavParamsMock);
+    itemFilterPage = new ItemFilterPage(
+      <any> new ViewController,
+      <any> new NavParamsMock,
+      <any> new AlertMock
+    );
   });
 
   it('is created', () => {
@@ -55,5 +59,12 @@ describe('ItemFilter Page', () => {
     spyOn(itemFilterPage.viewCtrl, 'dismiss');
     itemFilterPage.dismiss(TestData.brands[0]);
     expect(itemFilterPage.viewCtrl.dismiss).toHaveBeenCalledWith(TestData.brands[0], false);
+  });
+
+  it('creates an alert onCreate()', () => {
+    spyOn(itemFilterPage.alertCtrl, 'create').and.callThrough();
+    itemFilterPage.type = '';
+    itemFilterPage.onCreate();
+    expect(itemFilterPage.alertCtrl.create).toHaveBeenCalled();
   });
 });

--- a/src/pages/item-filter/item-filter.ts
+++ b/src/pages/item-filter/item-filter.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavParams, ViewController } from 'ionic-angular';
+import { NavParams, ViewController, AlertController } from 'ionic-angular';
 
 @Component({
   selector: 'page-item-filter',
@@ -12,7 +12,11 @@ export class ItemFilterPage {
   showNew: boolean = false;
   queryText: string = '';
 
-  constructor(public viewCtrl: ViewController, public navParams: NavParams) { }
+  constructor(
+    public viewCtrl: ViewController,
+    public navParams: NavParams,
+    public alertCtrl: AlertController
+  ) { }
 
   ngOnInit() {
     this.allElements = this.navParams.get('elements');
@@ -41,5 +45,31 @@ export class ItemFilterPage {
 
   dismiss(element?: Object, isNew: boolean = false) {
     this.viewCtrl.dismiss(element, isNew);
+  }
+
+  onCreate() {
+    let alert = this.alertCtrl.create({
+      title: `Create new ${this.type.toLowerCase()}`,
+      inputs: [
+        {
+          name: 'elementName',
+          placeholder: `${this.type} name`
+        }
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel'
+        },
+        {
+          text: 'Create',
+          handler: form => {
+            this.dismiss(form.elementName, true);
+          }
+        }
+      ]
+    });
+
+    alert.present();
   }
 }


### PR DESCRIPTION
Closes #154

Here's what it looks like now:

<img width="731" alt="screen shot 2017-03-31 at 3 21 35 pm" src="https://cloud.githubusercontent.com/assets/12487270/24566058/e11c6e7e-1625-11e7-8b31-df4fb531ede7.png">
<img width="739" alt="screen shot 2017-03-31 at 3 21 42 pm" src="https://cloud.githubusercontent.com/assets/12487270/24566057/e11c07ae-1625-11e7-99f7-48c8071e8ab1.png">

The users can also still add new brands, models or categories like before.