### PR TITLE
Add switch to user auth

### DIFF
--- a/src/providers/user-data.ts
+++ b/src/providers/user-data.ts
@@ -58,7 +58,7 @@ export class UserData {
     this.storage.get('id_token').then(
       token => {
         Raven.setUserContext({
-          id: this.jwtHelper.decodeToken(token).sub
+          id: this.jwtHelper.decodeToken(token).userID
         });
       }
     );


### PR DESCRIPTION
Closes #190 

This was way easier than I thought. Everything still works the same way it did since it is the same endpoints. The only element I had to change is the name of the property to get the userID in the token.