### PR TITLE
Change icon of rental tab

### DIFF
--- a/src/pages/tabs/tabs.html
+++ b/src/pages/tabs/tabs.html
@@ -1,4 +1,4 @@
 <ion-tabs>
-  <ion-tab [root]="tab1Root" tabTitle="Rental" tabIcon="qr-scanner"></ion-tab>
+  <ion-tab [root]="tab1Root" tabTitle="Rental" tabIcon="barcode"></ion-tab>
   <ion-tab [root]="tab2Root" tabTitle="Inventory" tabIcon="cube"></ion-tab>
 </ion-tabs>


### PR DESCRIPTION
Closes #210 

Here's how it looks now:

<img width="358" alt="screen shot 2017-04-12 at 10 01 20 am" src="https://cloud.githubusercontent.com/assets/12487270/24961520/06c1e894-1f67-11e7-97cd-a9a8317e2d67.png">
<img width="357" alt="screen shot 2017-04-12 at 10 01 25 am" src="https://cloud.githubusercontent.com/assets/12487270/24961519/06b98b4a-1f67-11e7-802c-8941582dc882.png">